### PR TITLE
feat: integrate one-way payment channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Stellar blockchain payment method for the [Machine Payments Protocol (MPP)](https://mpp.dev). Enables machine-to-machine payments using Soroban SAC token transfers on the Stellar network, with optional support for [one-way payment channels](https://github.com/stellar-experimental/one-way-channel) for high-frequency off-chain payments.
 
-Built on [mppx](https://github.com/nicholasgriffintn/mppx) — the TypeScript SDK for MPP.
 
 ## Payment modes
 
@@ -357,6 +356,17 @@ STELLAR_SECRET=S... pnpm demo:client      # Terminal 2
 
 Browser UI available at `http://localhost:3000/demo` once the server is running.
 
+### Channel end-to-end (with on-chain settlement)
+
+Run the full channel lifecycle — deploy, off-chain payments, and on-chain close — in a single command:
+
+```bash
+# Build the one-way-channel WASM first (see https://github.com/stellar-experimental/one-way-channel)
+WASM_PATH=path/to/channel.wasm ./demo/run-channel-e2e.sh
+```
+
+See [demo/channel-e2e-output.txt](demo/channel-e2e-output.txt) for example output with Stellar Expert links.
+
 ## Project structure
 
 ```
@@ -386,10 +396,16 @@ stellar-mpp-sdk/
 │           └── index.ts
 ├── examples/
 │   ├── server.ts           # Example server (Node http + tsx)
-│   └── client.ts           # Example client with progress events
+│   ├── client.ts           # Example client with progress events
+│   ├── channel-server.ts   # Channel server example
+│   ├── channel-client.ts   # Channel client example
+│   └── channel-close.ts    # On-chain channel close example
 ├── demo/
 │   ├── index.html          # Interactive browser UI (served at /demo)
-│   ├── run.sh              # All-in-one demo script
+│   ├── run.sh              # All-in-one charge demo script
+│   ├── run-channel.sh      # Off-chain channel demo script
+│   ├── run-channel-e2e.sh  # Full lifecycle e2e demo (deploy → pay → close)
+│   ├── channel-e2e-output.txt # Example e2e output with Stellar Expert links
 │   └── README.md           # Demo setup instructions
 └── dist/                   # Compiled output
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # stellar-mpp-sdk
 
-Stellar blockchain payment method for the [Machine Payments Protocol (MPP)](https://mpp.dev). Enables machine-to-machine payments using Soroban SAC token transfers on the Stellar network.
+Stellar blockchain payment method for the [Machine Payments Protocol (MPP)](https://mpp.dev). Enables machine-to-machine payments using Soroban SAC token transfers on the Stellar network, with optional support for [one-way payment channels](https://github.com/stellar-experimental/one-way-channel) for high-frequency off-chain payments.
 
 Built on [mppx](https://github.com/nicholasgriffintn/mppx) — the TypeScript SDK for MPP.
 
-## How it works
+## Payment modes
+
+### Charge (one-time transfers)
+
+Each payment is a Soroban SAC `transfer` settled on-chain individually.
 
 ```
 Client                          Server
@@ -29,6 +33,48 @@ Two credential modes:
 - **Pull** (default) — client signs the transaction XDR, server broadcasts it
 - **Push** — client broadcasts the transaction itself, sends the tx hash for server verification
 
+### Channel (off-chain commitments)
+
+Uses a [one-way payment channel](https://github.com/stellar-experimental/one-way-channel) contract. The funder deposits tokens into a channel once, then makes many off-chain payments by signing cumulative commitments — no per-payment on-chain transactions.
+
+```
+Client (Funder)                 Server (Recipient)
+  |                               |
+  |  [Channel opened on-chain     |
+  |   with initial deposit]       |
+  |                               |
+  |  GET /resource                |
+  |------------------------------>|
+  |                               |
+  |  402 Payment Required         |
+  |  (challenge: pay 1 XLM via    |
+  |   channel, cumulative: 0)     |
+  |<------------------------------|
+  |                               |
+  |  Sign commitment off-chain    |
+  |  (cumulative amount + sig)    |
+  |------------------------------>|
+  |                               |
+  |  Verify ed25519 signature     |
+  |  200 OK + data                |
+  |<------------------------------|
+  |                               |
+  |  GET /resource (again)        |
+  |------------------------------>|
+  |                               |
+  |  402 (cumulative: 1000000)    |
+  |<------------------------------|
+  |                               |
+  |  Sign commitment (cum: 2M)    |
+  |------------------------------>|
+  |                               |
+  |  Verify, 200 OK               |
+  |<------------------------------|
+  |                               |
+  |  [Server withdraws on-chain   |
+  |   when convenient]            |
+```
+
 ## Install
 
 ```bash
@@ -37,7 +83,7 @@ npm install stellar-mpp-sdk mppx @stellar/stellar-sdk
 
 ## Quick start
 
-### Server
+### Server (charge)
 
 ```ts
 import { Mppx, stellar } from 'stellar-mpp-sdk/server'
@@ -69,7 +115,7 @@ export async function handler(request: Request) {
 }
 ```
 
-### Client
+### Client (charge)
 
 ```ts
 import { Keypair } from '@stellar/stellar-sdk'
@@ -88,17 +134,69 @@ const response = await fetch('https://api.example.com/paid-resource')
 const data = await response.json()
 ```
 
+### Server (channel)
+
+```ts
+import { Mppx, stellar, Store } from 'stellar-mpp-sdk/channel/server'
+
+const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY,
+  methods: [
+    stellar.channel({
+      channel: 'CABC...',            // deployed one-way-channel contract address
+      commitmentKey: 'GFUNDER...',   // ed25519 public key for verifying commitments
+      store: Store.memory(),         // tracks cumulative amounts + replay protection
+      network: 'testnet',
+    }),
+  ],
+})
+
+export async function handler(request: Request) {
+  const result = await mppx.channel({
+    amount: '1',                     // 1 XLM per request (human-readable)
+    description: 'API call',
+  })(request)
+
+  if (result.status === 402) return result.challenge
+
+  return result.withReceipt(
+    Response.json({ data: 'paid content here' }),
+  )
+}
+```
+
+### Client (channel)
+
+```ts
+import { Keypair } from '@stellar/stellar-sdk'
+import { Mppx, stellar } from 'stellar-mpp-sdk/channel/client'
+
+Mppx.create({
+  methods: [
+    stellar.channel({
+      commitmentKey: Keypair.fromSecret('S...'), // ed25519 key matching the channel's commitment_key
+    }),
+  ],
+})
+
+const response = await fetch('https://api.example.com/paid-resource')
+const data = await response.json()
+```
+
 ## API
 
 ### Exports
 
 | Path | Exports |
 |------|---------|
-| `stellar-mpp-sdk` | `Methods`, constants (`USDC_SAC_TESTNET`, `XLM_SAC_MAINNET`, etc.), `toBaseUnits`, `fromBaseUnits` |
+| `stellar-mpp-sdk` | `Methods`, `ChannelMethods`, constants (`USDC_SAC_TESTNET`, `XLM_SAC_MAINNET`, etc.), `toBaseUnits`, `fromBaseUnits` |
 | `stellar-mpp-sdk/client` | `stellar`, `charge`, `Mppx` |
 | `stellar-mpp-sdk/server` | `stellar`, `charge`, `Mppx`, `Store`, `Expires` |
+| `stellar-mpp-sdk/channel` | `channel` (method schema) |
+| `stellar-mpp-sdk/channel/client` | `stellar`, `channel`, `Mppx` |
+| `stellar-mpp-sdk/channel/server` | `stellar`, `channel`, `withdraw`, `Mppx`, `Store`, `Expires` |
 
-### Server options
+### Server options (charge)
 
 ```ts
 stellar.charge({
@@ -112,7 +210,7 @@ stellar.charge({
 })
 ```
 
-### Client options
+### Client options (charge)
 
 ```ts
 stellar.charge({
@@ -125,9 +223,36 @@ stellar.charge({
 })
 ```
 
+### Server options (channel)
+
+```ts
+stellar.channel({
+  channel: string,                // on-chain channel contract address (C...)
+  commitmentKey: string | Keypair,// ed25519 public key for verifying commitments
+  network?: 'testnet' | 'public', // default: 'testnet'
+  decimals?: number,              // default: 7
+  rpcUrl?: string,                // custom Soroban RPC URL
+  store?: Store.Store,            // replay protection + cumulative amount tracking
+  withdrawKey?: Keypair,          // keypair for on-chain withdrawals
+})
+```
+
+### Client options (channel)
+
+```ts
+stellar.channel({
+  commitmentKey?: Keypair,        // ed25519 Keypair for signing commitments
+  commitmentSecret?: string,      // ed25519 secret key (S...)
+  rpcUrl?: string,                // custom Soroban RPC URL
+  onProgress?: (event) => void,   // lifecycle callback
+})
+```
+
 ### Progress events
 
 The `onProgress` callback receives events at each stage:
+
+**Charge events:**
 
 | Event | Fields | When |
 |-------|--------|------|
@@ -137,6 +262,14 @@ The `onProgress` callback receives events at each stage:
 | `paying` | — | Before broadcast (push mode) |
 | `confirming` | `hash` | Polling for confirmation (push mode) |
 | `paid` | `hash` | Transaction confirmed (push mode) |
+
+**Channel events:**
+
+| Event | Fields | When |
+|-------|--------|------|
+| `challenge` | `channel`, `amount`, `cumulativeAmount` | Challenge received |
+| `signing` | — | Before signing commitment |
+| `signed` | `cumulativeAmount` | Commitment signed |
 
 ### Fee sponsorship
 
@@ -163,6 +296,35 @@ stellar.charge({
   recipient: 'G...',
   currency: USDC_SAC_TESTNET,
   store: Store.memory(), // or Store.upstash(), Store.cloudflare()
+})
+```
+
+### One-way payment channels
+
+Payment channels allow many off-chain micro-payments with minimal on-chain transactions. The [one-way-channel](https://github.com/stellar-experimental/one-way-channel) contract is deployed on Soroban — no additional npm dependency is needed.
+
+**Prerequisites:**
+1. Deploy the channel contract on Stellar (see [one-way-channel repo](https://github.com/stellar-experimental/one-way-channel))
+2. The funder opens the channel with an initial token deposit, a `commitment_key` (ed25519 public key), the recipient address, and a refund waiting period
+3. Both client (funder) and server (recipient) use the channel contract address
+
+**How it works:**
+- The client signs cumulative commitment amounts off-chain using the ed25519 commitment key
+- The server verifies signatures by simulating `prepare_commitment` on the channel contract and checking the ed25519 signature
+- A `Store` is required on the server to track cumulative amounts across requests
+- The server can call `withdraw()` on-chain at any time to settle accumulated payments
+
+**On-chain withdrawal (server-side):**
+
+```ts
+import { withdraw } from 'stellar-mpp-sdk/channel/server'
+
+await withdraw({
+  channel: 'CABC...',           // channel contract address
+  amount: 8000000n,             // cumulative amount to withdraw
+  signature: commitmentSigBytes,// ed25519 signature from the latest commitment
+  withdrawKey: recipientKeypair,// keypair to sign the withdraw transaction
+  network: 'testnet',
 })
 ```
 
@@ -203,13 +365,24 @@ stellar-mpp-sdk/
 │   ├── constants.ts        # SAC addresses, RPC URLs, network passphrases
 │   ├── index.ts            # Root exports
 │   ├── client/
-│   │   ├── Charge.ts       # Client-side credential creation
-│   │   ├── Methods.ts      # stellar() convenience wrapper
+│   │   ├── Charge.ts       # Client-side credential creation (SAC transfer)
+│   │   ├── Methods.ts      # stellar.charge() convenience wrapper
 │   │   └── index.ts
-│   └── server/
-│       ├── Charge.ts       # Server-side verification + broadcast
-│       ├── Methods.ts      # stellar() convenience wrapper
-│       └── index.ts
+│   ├── server/
+│   │   ├── Charge.ts       # Server-side verification + broadcast
+│   │   ├── Methods.ts      # stellar.charge() convenience wrapper
+│   │   └── index.ts
+│   └── channel/
+│       ├── Methods.ts      # Method schema (name: 'stellar', intent: 'channel')
+│       ├── index.ts        # Channel root exports
+│       ├── client/
+│       │   ├── Channel.ts  # Client-side commitment signing
+│       │   ├── Methods.ts  # stellar.channel() convenience wrapper
+│       │   └── index.ts
+│       └── server/
+│           ├── Channel.ts  # Server-side commitment verification + withdraw
+│           ├── Methods.ts  # stellar.channel() convenience wrapper
+│           └── index.ts
 ├── examples/
 │   ├── server.ts           # Example server (Node http + tsx)
 │   └── client.ts           # Example client with progress events

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ stellar.channel({
   network?: 'testnet' | 'public', // default: 'testnet'
   decimals?: number,              // default: 7
   rpcUrl?: string,                // custom Soroban RPC URL
+  sourceAccount?: string,         // funded G... address for simulations
   store?: Store.Store,            // replay protection + cumulative amount tracking
-  withdrawKey?: Keypair,          // keypair for on-chain withdrawals
 })
 ```
 
@@ -244,6 +244,7 @@ stellar.channel({
   commitmentKey?: Keypair,        // ed25519 Keypair for signing commitments
   commitmentSecret?: string,      // ed25519 secret key (S...)
   rpcUrl?: string,                // custom Soroban RPC URL
+  sourceAccount?: string,         // funded G... address for simulations
   onProgress?: (event) => void,   // lifecycle callback
 })
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Client (Funder)                 Server (Recipient)
   |  Verify, 200 OK               |
   |<------------------------------|
   |                               |
-  |  [Server withdraws on-chain   |
+  |  [Server closes channel      |
   |   when convenient]            |
 ```
 
@@ -194,7 +194,7 @@ const data = await response.json()
 | `stellar-mpp-sdk/server` | `stellar`, `charge`, `Mppx`, `Store`, `Expires` |
 | `stellar-mpp-sdk/channel` | `channel` (method schema) |
 | `stellar-mpp-sdk/channel/client` | `stellar`, `channel`, `Mppx` |
-| `stellar-mpp-sdk/channel/server` | `stellar`, `channel`, `withdraw`, `Mppx`, `Store`, `Expires` |
+| `stellar-mpp-sdk/channel/server` | `stellar`, `channel`, `close`, `Mppx`, `Store`, `Expires` |
 
 ### Server options (charge)
 
@@ -313,18 +313,18 @@ Payment channels allow many off-chain micro-payments with minimal on-chain trans
 - The client signs cumulative commitment amounts off-chain using the ed25519 commitment key
 - The server verifies signatures by simulating `prepare_commitment` on the channel contract and checking the ed25519 signature
 - A `Store` is required on the server to track cumulative amounts across requests
-- The server can call `withdraw()` on-chain at any time to settle accumulated payments
+- The server can call `close()` on-chain at any time to settle accumulated payments
 
-**On-chain withdrawal (server-side):**
+**On-chain close (server-side):**
 
 ```ts
-import { withdraw } from 'stellar-mpp-sdk/channel/server'
+import { close } from 'stellar-mpp-sdk/channel/server'
 
-await withdraw({
+await close({
   channel: 'CABC...',           // channel contract address
-  amount: 8000000n,             // cumulative amount to withdraw
+  amount: 8000000n,             // commitment amount to close with
   signature: commitmentSigBytes,// ed25519 signature from the latest commitment
-  withdrawKey: recipientKeypair,// keypair to sign the withdraw transaction
+  closeKey: recipientKeypair,   // keypair to sign the close transaction
   network: 'testnet',
 })
 ```
@@ -381,7 +381,7 @@ stellar-mpp-sdk/
 │       │   ├── Methods.ts  # stellar.channel() convenience wrapper
 │       │   └── index.ts
 │       └── server/
-│           ├── Channel.ts  # Server-side commitment verification + withdraw
+│           ├── Channel.ts  # Server-side commitment verification + close
 │           ├── Methods.ts  # stellar.channel() convenience wrapper
 │           └── index.ts
 ├── examples/

--- a/demo/README.md
+++ b/demo/README.md
@@ -190,7 +190,7 @@ Client (Funder)                 Server (Recipient)
   |<------------------------------|
 ```
 
-No on-chain transactions happen during payments. The server can withdraw accumulated funds on-chain at any time.
+No on-chain transactions happen during payments. The server can close the channel and settle accumulated funds on-chain at any time.
 
 ### Channel environment variables
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -8,7 +8,7 @@ Two demo modes are available:
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - A funded Stellar **testnet** account (create one at [Stellar Laboratory](https://laboratory.stellar.org/#account-creator?network=test))
 - `pnpm install` (from project root)
 - For the **channel demo**: a deployed [one-way-channel](https://github.com/stellar-experimental/one-way-channel) contract on testnet

--- a/demo/README.md
+++ b/demo/README.md
@@ -202,3 +202,58 @@ No on-chain transactions happen during payments. The server can close the channe
 | `MPP_SECRET_KEY` | No | MPP signing key (defaults to `stellar-mpp-channel-demo-secret`) |
 | `PORT` | No | Server port (defaults to `3001`) |
 | `SERVER_URL` | No | Client target URL (defaults to `http://localhost:3001`) |
+
+---
+
+## Channel E2E Demo (full lifecycle with on-chain settlement)
+
+Runs the **complete channel lifecycle** from scratch: create accounts → deploy contract → off-chain payments → on-chain close. All transactions are reported with Stellar Expert links for verification.
+
+See [channel-e2e-output.txt](channel-e2e-output.txt) for example output from a real testnet run.
+
+### Prerequisites
+
+- Everything from the channel demo above, plus:
+- [stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli) installed
+- The one-way-channel contract WASM file (build from the [one-way-channel repo](https://github.com/stellar-experimental/one-way-channel))
+
+### Build the WASM
+
+```bash
+git clone https://github.com/stellar-experimental/one-way-channel
+cd one-way-channel
+stellar contract build
+# WASM is at: target/wasm32v1-none/release/channel.wasm
+```
+
+### Run the demo
+
+```bash
+WASM_PATH=path/to/channel.wasm ./demo/run-channel-e2e.sh
+```
+
+The script will:
+1. Create fresh funded testnet accounts (funder + recipient)
+2. Generate a random ed25519 commitment keypair
+3. Upload WASM and deploy the channel contract (on-chain)
+4. Run 2 off-chain MPP payments via the SDK (no on-chain tx)
+5. Close the channel on-chain — settling funds to recipient, refunding remainder to funder
+6. Print all Stellar Expert links for transaction verification
+
+### What happens on-chain
+
+| Step | Transaction | On-chain? |
+|------|------------|-----------|
+| Create accounts | Friendbot funding | Yes |
+| Upload WASM | `uploadWasm` | Yes |
+| Deploy contract | `__constructor` + deposit | Yes |
+| Payment 1 | Commitment signature only | **No** |
+| Payment 2 | Commitment signature only | **No** |
+| Close channel | `close(amount, sig)` | Yes |
+
+### E2E environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `WASM_PATH` | Yes | Path to the compiled `channel.wasm` file |
+| `PORT` | No | Server port (defaults to `3002`) |

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,11 +2,20 @@
 
 Interactive playground for testing the Stellar MPP payment flow — via browser UI or CLI.
 
+Two demo modes are available:
+- **Charge** — one-time on-chain SAC token transfers (default)
+- **Channel** — off-chain payment channel commitments (no on-chain tx per payment)
+
 ## Prerequisites
 
 - Node.js 18+
 - A funded Stellar **testnet** account (create one at [Stellar Laboratory](https://laboratory.stellar.org/#account-creator?network=test))
 - `pnpm install` (from project root)
+- For the **channel demo**: a deployed [one-way-channel](https://github.com/stellar-experimental/one-way-channel) contract on testnet
+
+---
+
+## Charge Demo (one-time transfers)
 
 ## Option 1: All-in-one script
 
@@ -85,8 +94,111 @@ Client                          Server
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `STELLAR_RECIPIENT` | Server | Your Stellar public key (G..., 56 chars) |
-| `STELLAR_SECRET` | Client | Your Stellar secret key (S...) |
+| `STELLAR_RECIPIENT` | Charge server | Your Stellar public key (G..., 56 chars) |
+| `STELLAR_SECRET` | Charge client | Your Stellar secret key (S...) |
 | `MPP_SECRET_KEY` | No | MPP signing key (defaults to `stellar-mpp-demo-secret`) |
-| `PORT` | No | Server port (defaults to `3000`) |
-| `SERVER_URL` | No | Client target URL (defaults to `http://localhost:3000`) |
+| `PORT` | No | Server port (defaults to `3000` for charge, `3001` for channel) |
+| `SERVER_URL` | No | Client target URL (defaults to `http://localhost:3000` or `3001`) |
+
+---
+
+## Channel Demo (off-chain commitments)
+
+Uses a [one-way payment channel](https://github.com/stellar-experimental/one-way-channel) contract for off-chain micro-payments. The funder signs cumulative ed25519 commitments — **no on-chain transaction per payment**.
+
+### Prerequisites
+
+You need a deployed channel contract. See the main [README](../README.md#one-way-payment-channels) for deployment instructions, or use these pre-deployed testnet values:
+
+| Item | Value |
+|------|-------|
+| Channel contract | `CBU3P5BAU6CYGPAVY7TGGGNEPCS7H73IA3L677Z3CFZSGFYB7UFK4IMS` |
+| Commitment public key | `b83ee77019d9ca0aac432139fe0159ec01b5d31f58905fdc089980be05b7c5fd` |
+| Commitment secret key | `73b51cad30e14119e78d9a3d5d143a55c07f57c53fe9b95aa6bb061d0d4afb4f` |
+
+### Option 1: All-in-one script
+
+```bash
+./demo/run-channel.sh
+```
+
+Or pass keys directly:
+
+```bash
+CHANNEL_CONTRACT=CBU3P5BAU6CYGPAVY7TGGGNEPCS7H73IA3L677Z3CFZSGFYB7UFK4IMS \
+COMMITMENT_PUBKEY=b83ee77019d9ca0aac432139fe0159ec01b5d31f58905fdc089980be05b7c5fd \
+COMMITMENT_SECRET=73b51cad30e14119e78d9a3d5d143a55c07f57c53fe9b95aa6bb061d0d4afb4f \
+./demo/run-channel.sh
+```
+
+### Option 2: Two terminals
+
+```bash
+# Terminal 1 — start channel server
+CHANNEL_CONTRACT=CBU3P5BAU6CYGPAVY7TGGGNEPCS7H73IA3L677Z3CFZSGFYB7UFK4IMS \
+COMMITMENT_PUBKEY=b83ee77019d9ca0aac432139fe0159ec01b5d31f58905fdc089980be05b7c5fd \
+npx tsx examples/channel-server.ts
+```
+
+```bash
+# Terminal 2 — run channel client
+COMMITMENT_SECRET=73b51cad30e14119e78d9a3d5d143a55c07f57c53fe9b95aa6bb061d0d4afb4f \
+npx tsx examples/channel-client.ts
+```
+
+Or use npm scripts:
+
+```bash
+# Terminal 1
+CHANNEL_CONTRACT=C... COMMITMENT_PUBKEY=... pnpm demo:channel-server
+
+# Terminal 2
+COMMITMENT_SECRET=... pnpm demo:channel-client
+```
+
+### How the channel flow works
+
+```
+Client (Funder)                 Server (Recipient)
+  |                               |
+  |  GET /resource                |
+  |------------------------------>|
+  |                               |
+  |  402 Payment Required         |
+  |  (challenge: 0.1 XLM via     |
+  |   channel, cumulative: 0)     |
+  |<------------------------------|
+  |                               |
+  |  Sign commitment (cum: 1M)    |
+  |  Send signature + amount      |
+  |------------------------------>|
+  |                               |
+  |  Verify ed25519 signature     |
+  |  200 OK + content             |
+  |<------------------------------|
+  |                               |
+  |  GET /resource (again)        |
+  |------------------------------>|
+  |                               |
+  |  402 (cumulative: 1000000)    |
+  |<------------------------------|
+  |                               |
+  |  Sign commitment (cum: 2M)    |
+  |------------------------------>|
+  |                               |
+  |  Verify, 200 OK               |
+  |<------------------------------|
+```
+
+No on-chain transactions happen during payments. The server can withdraw accumulated funds on-chain at any time.
+
+### Channel environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CHANNEL_CONTRACT` | Server | Deployed channel contract address (C..., 56 chars) |
+| `COMMITMENT_PUBKEY` | Server | Ed25519 commitment public key (64 hex chars) |
+| `COMMITMENT_SECRET` | Client | Ed25519 commitment secret key (64 hex chars) |
+| `MPP_SECRET_KEY` | No | MPP signing key (defaults to `stellar-mpp-channel-demo-secret`) |
+| `PORT` | No | Server port (defaults to `3001`) |
+| `SERVER_URL` | No | Client target URL (defaults to `http://localhost:3001`) |

--- a/demo/channel-e2e-output.txt
+++ b/demo/channel-e2e-output.txt
@@ -1,0 +1,117 @@
+═══════════════════════════════════════════════════════════
+  Stellar MPP Channel — End-to-End Demo
+  Full lifecycle: deploy → off-chain payments → on-chain close
+═══════════════════════════════════════════════════════════
+
+Demo ID: mpp-e2e-1773942774
+
+═══ Step 1: Creating funded testnet accounts ═══
+
+  Creating funder account...
+  ✔ Funder:    GDGGJUVCIE3M4ZSCWJV4EW372P3OQ5GKBSCZFOLHMT5ZLXTZMTKKFZHP
+  Creating recipient account...
+  ✔ Recipient: GAHRDOKGD26XPWB2GNWFOCDJE5ZSJECLHAFJRLDEBZPVE6VR3HDLCJTV
+
+═══ Step 2: Generating ed25519 commitment keypair ═══
+
+  ✔ Public:  645b0ea155d757339764c75b2659886f5099c2bd3b9f6d49898a98c011147f1a
+  ✔ Secret:  a6e7a144...2dd66dbd (hidden)
+
+═══ Step 3: Deploying channel contract ═══
+
+  Uploading WASM...
+  ✔ WASM hash: f9b7fdf860ce427097226f45f72b336763ca55d46c967076a94eb9682d8c484b
+  Deploying channel (deposit: 10000000 stroops = 1.0 XLM)...
+  ✔ Contract:  CB2B347IE6N5C2EDV2SGUQ22KM6WFL6CWFMPFOTUYNUITVXUREOYPLAD
+
+  Channel balance after deploy:
+    "10000000" stroops
+
+═══ Step 4: Off-chain MPP payments (2 requests × 0.1 XLM) ═══
+
+  Starting channel server on port 3002...
+  🚀 Stellar MPP Channel server running on http://localhost:3002
+     Channel contract: CB2B347IE6N5C2EDV2SGUQ22KM6WFL6CWFMPFOTUYNUITVXUREOYPLAD
+
+  Running channel client (2 off-chain payments)...
+
+  Using commitment key: GBSFWDVBKXLVOM4XMTDVWJSZRBXVBGOCXU5Z63KJRGFJRQARCR7RUMB3
+
+  Request 1:
+    [17:53:26.904] 💳 Challenge received — 1000000 stroops via channel CB2B347IE6N5...
+    [17:53:26.904]    Cumulative amount will be: 1000000 stroops
+    [17:53:27.217] ✍️  Signing commitment...
+    [17:53:27.218] ✅ Commitment signed (cumulative: 1000000 stroops)
+
+    --- Response (200) ---
+    {
+      "message": "Payment verified via channel commitment — here is your content.",
+      "timestamp": "2026-03-19T17:53:27.579Z",
+      "note": "No on-chain transaction was needed for this payment!"
+    }
+
+  Request 2:
+    [17:53:27.591] 💳 Challenge received — 1000000 stroops via channel CB2B347IE6N5...
+    [17:53:27.591]    Cumulative amount will be: 2000000 stroops
+    [17:53:27.794] ✍️  Signing commitment...
+    [17:53:27.795] ✅ Commitment signed (cumulative: 2000000 stroops)
+
+    --- Response 2 (200) ---
+    {
+      "message": "Payment verified via channel commitment — here is your content.",
+      "timestamp": "2026-03-19T17:53:27.993Z",
+      "note": "No on-chain transaction was needed for this payment!"
+    }
+
+  ✔ Server stopped. Off-chain phase complete.
+  Cumulative committed: 2000000 stroops (0.2 XLM)
+
+═══ Step 5: On-chain settlement — closing channel ═══
+
+  Closing channel CB2B347IE6N5C2EDV2SGUQ22KM6WFL6CWFMPFOTUYNUITVXUREOYPLAD
+    Amount: 2000000 stroops (0.2 XLM)
+    Close key: GAHRDOKGD26XPWB2GNWFOCDJE5ZSJECLHAFJRLDEBZPVE6VR3HDLCJTV
+
+  1. Simulating prepare_commitment...
+     Commitment: 0000001100000001000000040000000f00000006...
+  2. Signing commitment...
+     Signature: 567c6748ed5a06a849f040a762a7e513a7f4d99e...
+  3. Submitting close transaction...
+
+  ═══════════════════════════════════════════════════════
+    ✅ Channel closed on-chain!
+    Transaction: c6c54df5be7b469e1259e85a05c8b7d5fdc71bebb1f937c4b5e3b540111d6463
+    Verify:      https://stellar.expert/explorer/testnet/tx/c6c54df5be7b469e1259e85a05c8b7d5fdc71bebb1f937c4b5e3b540111d6463
+  ═══════════════════════════════════════════════════════
+
+═══ Step 6: Final channel state ═══
+
+  Channel balance after close:
+    "0" stroops
+
+  (close transferred 2000000 to recipient, auto-refunded remainder to funder)
+
+═══════════════════════════════════════════════════════════════════
+  Demo Complete — Verify on Stellar Expert (testnet)
+═══════════════════════════════════════════════════════════════════
+
+  Accounts:
+    Funder:    https://stellar.expert/explorer/testnet/account/GDGGJUVCIE3M4ZSCWJV4EW372P3OQ5GKBSCZFOLHMT5ZLXTZMTKKFZHP
+    Recipient: https://stellar.expert/explorer/testnet/account/GAHRDOKGD26XPWB2GNWFOCDJE5ZSJECLHAFJRLDEBZPVE6VR3HDLCJTV
+
+  Contract:
+    Channel:   https://stellar.expert/explorer/testnet/contract/CB2B347IE6N5C2EDV2SGUQ22KM6WFL6CWFMPFOTUYNUITVXUREOYPLAD
+
+  What happened:
+    1. Funder deployed channel contract with 10000000 stroops deposit
+    2. Client made 2 off-chain payments (0.1 XLM each) — no on-chain tx
+    3. Recipient closed channel for 2000000 stroops on-chain
+       → 2000000 transferred to recipient
+       → remainder auto-refunded to funder
+
+  On-chain transactions to verify:
+    • WASM upload         — see funder account history
+    • Contract deploy     — https://stellar.expert/explorer/testnet/tx/9c7db8b91bc3768d6ec1bbf063f0b95062f27c485afa0e210707fd3fb509bc3f
+    • Channel close       — https://stellar.expert/explorer/testnet/tx/c6c54df5be7b469e1259e85a05c8b7d5fdc71bebb1f937c4b5e3b540111d6463
+
+═══════════════════════════════════════════════════════════════════

--- a/demo/output-run.txt
+++ b/demo/output-run.txt
@@ -1,0 +1,41 @@
+sagar@sagar-K9FV9RT447-mbp stellar-mpp-sdk % ./demo/run.sh
+
+Enter your Stellar public key (recipient, starts with G):
+  STELLAR_RECIPIENT=GC6ZBCI6M6PMBMRCZQMOGCUOZKFREM7P6G2NC3TD5FMYX3YLPAACQMJY
+
+Enter your Stellar secret key (payer, starts with S):
+  STELLAR_SECRET=
+
+══════════════════════════════════════════════════
+  Stellar MPP Demo
+  Recipient: GC6ZBCI6...QMJY
+  Payer:     SC6Z****
+══════════════════════════════════════════════════
+
+▶ Starting server...
+🚀 Stellar MPP server running on http://localhost:3000
+🌐 Demo UI available at http://localhost:3000/demo
+   Recipient: GC6ZBCI6M6PMBMRCZQMOGCUOZKFREM7P6G2NC3TD5FMYX3YLPAACQMJY
+
+▶ Running client...
+
+Using Stellar account: GDZYARK2HZX2XP7BDOCK2RLD4IE5HQAZWFHQ3K5TEAEWAIUNB3LRHDYT
+
+Requesting http://localhost:3000...
+
+[17:58:19.451] 💳 Challenge received — 0.0100000 to GC6ZBCI6M6PMBMRCZQMOGCUOZKFREM7P6G2NC3TD5FMYX3YLPAACQMJY
+[17:58:19.758] ✍️  Signing transaction...
+[17:58:19.760] ✅ Transaction signed (1008 bytes XDR)
+
+--- Response (200) ---
+{
+  "message": "Payment verified — here is your premium content.",
+  "timestamp": "2026-03-19T17:58:22.230Z"
+}
+
+══════════════════════════════════════════════════
+  Demo complete!
+  UI also available at: http://localhost:3000/demo
+══════════════════════════════════════════════════
+
+Press Ctrl+C to stop the server.

--- a/demo/run-channel-e2e.sh
+++ b/demo/run-channel-e2e.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+#
+# Stellar MPP Channel — End-to-End Demo with On-Chain Settlement
+#
+# Full lifecycle: deploy → off-chain payments → on-chain close
+# All transactions reported for verification on Stellar Expert.
+#
+# Prerequisites:
+#   - stellar CLI (https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli)
+#   - Node.js 20+
+#   - one-way-channel WASM (build from https://github.com/stellar-experimental/one-way-channel)
+#
+# Usage:
+#   WASM_PATH=path/to/channel.wasm ./demo/run-channel-e2e.sh
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+cat << 'BANNER'
+
+═══════════════════════════════════════════════════════════
+  Stellar MPP Channel — End-to-End Demo
+  Full lifecycle: deploy → off-chain payments → on-chain close
+═══════════════════════════════════════════════════════════
+
+BANNER
+
+# ── Check prerequisites ──────────────────────────────────────────────────────
+
+WASM_PATH="${WASM_PATH:-}"
+
+if ! command -v stellar &>/dev/null; then
+  echo "❌ stellar CLI not found."
+  echo "   Install: https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli"
+  exit 1
+fi
+
+if ! command -v npx &>/dev/null; then
+  echo "❌ npx not found. Install Node.js 20+."
+  exit 1
+fi
+
+if [ -z "$WASM_PATH" ]; then
+  echo "❌ Set WASM_PATH to the one-way-channel contract WASM file."
+  echo ""
+  echo "   Build it from the one-way-channel repo:"
+  echo "     git clone https://github.com/stellar-experimental/one-way-channel"
+  echo "     cd one-way-channel"
+  echo "     stellar contract build"
+  echo "     # WASM is at: target/wasm32v1-none/release/channel.wasm"
+  echo ""
+  echo "   Then run:"
+  echo "     WASM_PATH=path/to/channel.wasm ./demo/run-channel-e2e.sh"
+  exit 1
+fi
+
+if [ ! -f "$WASM_PATH" ]; then
+  echo "❌ WASM file not found: $WASM_PATH"
+  exit 1
+fi
+
+# ── Unique names for this demo run ───────────────────────────────────────────
+
+DEMO_ID="mpp-e2e-$(date +%s)"
+FUNDER="${DEMO_ID}-funder"
+RECIPIENT="${DEMO_ID}-recipient"
+DEPOSIT=10000000  # 1 XLM initial deposit (in stroops)
+PORT=${PORT:-3002}
+CLOSE_AMOUNT=2000000  # 0.2 XLM — cumulative from 2 payments of 0.1 XLM
+
+echo "Demo ID: $DEMO_ID"
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Step 1: Create funded testnet accounts
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "═══ Step 1: Creating funded testnet accounts ═══"
+echo ""
+
+echo "  Creating funder account..."
+stellar keys generate "$FUNDER" --fund --network testnet --overwrite 2>/dev/null
+FUNDER_ADDR=$(stellar keys address "$FUNDER")
+echo "  ✔ Funder:    $FUNDER_ADDR"
+
+echo "  Creating recipient account..."
+stellar keys generate "$RECIPIENT" --fund --network testnet --overwrite 2>/dev/null
+RECIPIENT_ADDR=$(stellar keys address "$RECIPIENT")
+echo "  ✔ Recipient: $RECIPIENT_ADDR"
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Step 2: Generate ed25519 commitment keypair
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "═══ Step 2: Generating ed25519 commitment keypair ═══"
+echo ""
+
+# Generate a random ed25519 keypair using Node.js + stellar-sdk
+read -r COMMITMENT_SKEY COMMITMENT_PKEY < <(npx tsx -e "
+import crypto from 'node:crypto'
+import { Keypair } from '@stellar/stellar-sdk'
+const seed = crypto.randomBytes(32)
+const kp = Keypair.fromRawEd25519Seed(seed)
+console.log(seed.toString('hex') + ' ' + Buffer.from(kp.rawPublicKey()).toString('hex'))
+" 2>/dev/null)
+
+echo "  ✔ Public:  $COMMITMENT_PKEY"
+echo "  ✔ Secret:  ${COMMITMENT_SKEY:0:8}...${COMMITMENT_SKEY: -8} (hidden)"
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Step 3: Upload WASM and deploy channel contract
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "═══ Step 3: Deploying channel contract ═══"
+echo ""
+
+echo "  Uploading WASM..."
+WASM_HASH=$(stellar contract upload \
+  --wasm "$WASM_PATH" \
+  --source "$FUNDER" \
+  --network testnet)
+echo "  ✔ WASM hash: $WASM_HASH"
+
+echo "  Deploying channel (deposit: $DEPOSIT stroops = $(echo "scale=1; $DEPOSIT / 10000000" | bc) XLM)..."
+CONTRACT=$(stellar contract deploy \
+  --wasm-hash "$WASM_HASH" \
+  --source "$FUNDER" \
+  --network testnet \
+  -- \
+  --token native \
+  --from "$FUNDER" \
+  --commitment_key "$COMMITMENT_PKEY" \
+  --to "$RECIPIENT" \
+  --amount "$DEPOSIT" \
+  --refund_waiting_period 100)
+echo "  ✔ Contract:  $CONTRACT"
+
+echo ""
+echo "  Channel balance after deploy:"
+BALANCE_BEFORE=$(stellar contract invoke \
+  --id "$CONTRACT" \
+  --source "$FUNDER" \
+  --network testnet \
+  --send=no \
+  -- balance)
+echo "    $BALANCE_BEFORE stroops"
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Step 4: Off-chain MPP payments (no on-chain transactions)
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "═══ Step 4: Off-chain MPP payments (2 requests × 0.1 XLM) ═══"
+echo ""
+
+# Kill any existing process on the port
+if command -v lsof &>/dev/null && lsof -ti:$PORT &>/dev/null; then
+  echo "  ⚠ Port $PORT in use — freeing it..."
+  lsof -ti:$PORT | xargs kill -9 2>/dev/null
+  sleep 1
+fi
+
+echo "  Starting channel server on port $PORT..."
+CHANNEL_CONTRACT="$CONTRACT" \
+COMMITMENT_PUBKEY="$COMMITMENT_PKEY" \
+SOURCE_ACCOUNT="$FUNDER_ADDR" \
+PORT=$PORT \
+npx tsx examples/channel-server.ts &
+SERVER_PID=$!
+trap "kill $SERVER_PID 2>/dev/null" EXIT
+
+# Wait for server to be ready
+for i in $(seq 1 15); do
+  if curl -s "http://localhost:$PORT" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.5
+done
+
+echo ""
+echo "  Running channel client (2 off-chain payments)..."
+echo ""
+
+COMMITMENT_SECRET="$COMMITMENT_SKEY" \
+SOURCE_ACCOUNT="$FUNDER_ADDR" \
+SERVER_URL="http://localhost:$PORT" \
+npx tsx examples/channel-client.ts
+
+echo ""
+
+# Stop server
+kill $SERVER_PID 2>/dev/null || true
+wait $SERVER_PID 2>/dev/null || true
+trap - EXIT
+
+echo "  ✔ Server stopped. Off-chain phase complete."
+echo "  Cumulative committed: $CLOSE_AMOUNT stroops ($(echo "scale=1; $CLOSE_AMOUNT / 10000000" | bc) XLM)"
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Step 5: On-chain settlement — close the channel
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "═══ Step 5: On-chain settlement — closing channel ═══"
+echo ""
+
+RECIPIENT_SECRET=$(stellar keys show "$RECIPIENT")
+
+CHANNEL_CONTRACT="$CONTRACT" \
+COMMITMENT_SECRET="$COMMITMENT_SKEY" \
+CLOSE_SECRET="$RECIPIENT_SECRET" \
+AMOUNT="$CLOSE_AMOUNT" \
+npx tsx examples/channel-close.ts
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Step 6: Verify final state
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "═══ Step 6: Final channel state ═══"
+echo ""
+
+echo "  Channel balance after close:"
+BALANCE_AFTER=$(stellar contract invoke \
+  --id "$CONTRACT" \
+  --source "$FUNDER" \
+  --network testnet \
+  --send=no \
+  -- balance)
+echo "    $BALANCE_AFTER stroops"
+echo ""
+echo "  (close transferred $CLOSE_AMOUNT to recipient, auto-refunded remainder to funder)"
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Summary
+# ══════════════════════════════════════════════════════════════════════════════
+
+cat << SUMMARY
+
+═══════════════════════════════════════════════════════════════════
+  Demo Complete — Verify on Stellar Expert (testnet)
+═══════════════════════════════════════════════════════════════════
+
+  Accounts:
+    Funder:    https://stellar.expert/explorer/testnet/account/$FUNDER_ADDR
+    Recipient: https://stellar.expert/explorer/testnet/account/$RECIPIENT_ADDR
+
+  Contract:
+    Channel:   https://stellar.expert/explorer/testnet/contract/$CONTRACT
+
+  What happened:
+    1. Funder deployed channel contract with $DEPOSIT stroops deposit
+    2. Client made 2 off-chain payments (0.1 XLM each) — no on-chain tx
+    3. Recipient closed channel for $CLOSE_AMOUNT stroops on-chain
+       → $CLOSE_AMOUNT transferred to recipient
+       → remainder auto-refunded to funder
+
+  Look for these transactions on the funder's account:
+    • Contract upload (uploadWasm)
+    • Contract deploy (__constructor) with $DEPOSIT stroops transfer
+  And on the recipient's account:
+    • Channel close (close) — the settlement transaction
+
+═══════════════════════════════════════════════════════════════════
+SUMMARY

--- a/demo/run-channel.sh
+++ b/demo/run-channel.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")/.."
 
 # ── Check prerequisites ──────────────────────────────────────────────────────
 if ! command -v npx &>/dev/null; then
-  echo "❌ npx not found. Install Node.js 18+ first."
+  echo "❌ npx not found. Install Node.js 20+ first."
   exit 1
 fi
 

--- a/demo/run-channel.sh
+++ b/demo/run-channel.sh
@@ -41,6 +41,13 @@ if [ -z "${COMMITMENT_SECRET:-}" ]; then
   export COMMITMENT_SECRET="${commitment_secret}"
 fi
 
+if [ -z "${SOURCE_ACCOUNT:-}" ]; then
+  echo ""
+  echo "Enter a funded testnet Stellar account (G..., 56 chars) for simulations:"
+  read -rp "  SOURCE_ACCOUNT=" source_account
+  export SOURCE_ACCOUNT="${source_account}"
+fi
+
 echo ""
 echo "══════════════════════════════════════════════════"
 echo "  Stellar MPP Channel Demo"

--- a/demo/run-channel.sh
+++ b/demo/run-channel.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Stellar MPP Channel Demo — run channel server + client end-to-end
+#
+# Uses the one-way payment channel for off-chain micro-payments.
+# No on-chain transaction per payment — only commitment signatures.
+#
+# Usage:
+#   ./demo/run-channel.sh                    # prompts for keys
+#   CHANNEL_CONTRACT=C... COMMITMENT_PUBKEY=... COMMITMENT_SECRET=... ./demo/run-channel.sh
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# ── Check prerequisites ──────────────────────────────────────────────────────
+if ! command -v npx &>/dev/null; then
+  echo "❌ npx not found. Install Node.js 18+ first."
+  exit 1
+fi
+
+# ── Prompt for keys if not set ────────────────────────────────────────────────
+if [ -z "${CHANNEL_CONTRACT:-}" ]; then
+  echo ""
+  echo "Enter the channel contract address (starts with C, 56 chars):"
+  read -rp "  CHANNEL_CONTRACT=" channel_contract
+  export CHANNEL_CONTRACT="${channel_contract}"
+fi
+
+if [ -z "${COMMITMENT_PUBKEY:-}" ]; then
+  echo ""
+  echo "Enter the ed25519 commitment public key (64 hex chars):"
+  read -rp "  COMMITMENT_PUBKEY=" commitment_pubkey
+  export COMMITMENT_PUBKEY="${commitment_pubkey}"
+fi
+
+if [ -z "${COMMITMENT_SECRET:-}" ]; then
+  echo ""
+  echo "Enter the ed25519 commitment secret key (64 hex chars):"
+  read -rsp "  COMMITMENT_SECRET=" commitment_secret
+  echo ""
+  export COMMITMENT_SECRET="${commitment_secret}"
+fi
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo "  Stellar MPP Channel Demo"
+echo "  Contract: ${CHANNEL_CONTRACT:0:12}...${CHANNEL_CONTRACT: -4}"
+echo "  Commit key: ${COMMITMENT_PUBKEY:0:16}..."
+echo "══════════════════════════════════════════════════"
+echo ""
+
+# ── Start server in background ────────────────────────────────────────────────
+PORT=${PORT:-3001}
+
+# Kill any existing process on the port
+if lsof -ti:$PORT &>/dev/null; then
+  echo "⚠ Port $PORT in use — freeing it..."
+  lsof -ti:$PORT | xargs kill -9 2>/dev/null
+  sleep 1
+fi
+
+echo "▶ Starting channel server on port $PORT..."
+PORT=$PORT npx tsx examples/channel-server.ts &
+SERVER_PID=$!
+trap "kill $SERVER_PID 2>/dev/null" EXIT
+
+# Wait for server to be ready
+for i in $(seq 1 10); do
+  if curl -s http://localhost:$PORT >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.5
+done
+
+echo ""
+echo "▶ Running channel client (2 requests to show cumulative growth)..."
+echo ""
+
+# ── Run client ────────────────────────────────────────────────────────────────
+SERVER_URL="http://localhost:$PORT" npx tsx examples/channel-client.ts
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo "  Channel Demo complete!"
+echo "  Two payments made via off-chain commitments."
+echo "  No on-chain transactions were needed!"
+echo "══════════════════════════════════════════════════"
+echo ""
+echo "Press Ctrl+C to stop the server."
+wait $SERVER_PID

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$0")/.."
 
 # ── Check prerequisites ──────────────────────────────────────────────────────
 if ! command -v npx &>/dev/null; then
-  echo "❌ npx not found. Install Node.js 18+ first."
+  echo "❌ npx not found. Install Node.js 20+ first."
   exit 1
 fi
 

--- a/examples/channel-client.ts
+++ b/examples/channel-client.ts
@@ -27,6 +27,7 @@ Mppx.create({
   methods: [
     stellar.channel({
       commitmentKey,
+      sourceAccount: process.env.SOURCE_ACCOUNT,
       onProgress(event) {
         const ts = new Date().toISOString().slice(11, 23)
         switch (event.type) {

--- a/examples/channel-client.ts
+++ b/examples/channel-client.ts
@@ -1,0 +1,65 @@
+/**
+ * Example: Stellar MPP Channel Client
+ *
+ * Automatically handles 402 Payment Required responses by signing
+ * off-chain commitment updates — no on-chain transaction per payment.
+ *
+ * Usage:
+ *   COMMITMENT_SECRET=73b5... npx tsx examples/channel-client.ts
+ */
+
+import { Keypair } from '@stellar/stellar-sdk'
+import { Mppx } from 'mppx/client'
+import { stellar } from '../sdk/src/channel/client/index.js'
+
+const commitmentSecret = process.env.COMMITMENT_SECRET
+if (!commitmentSecret || commitmentSecret.length !== 64) {
+  console.error('Usage: COMMITMENT_SECRET=<64-char-hex-ed25519-secret> npx tsx examples/channel-client.ts')
+  process.exit(1)
+}
+
+// Convert the raw ed25519 secret key (hex) to a Stellar Keypair for signing
+const commitmentKey = Keypair.fromRawEd25519Seed(Buffer.from(commitmentSecret, 'hex'))
+console.log(`Using commitment key: ${commitmentKey.publicKey()}`)
+
+// Polyfill global fetch with automatic 402 handling
+Mppx.create({
+  methods: [
+    stellar.channel({
+      commitmentKey,
+      onProgress(event) {
+        const ts = new Date().toISOString().slice(11, 23)
+        switch (event.type) {
+          case 'challenge':
+            console.log(`[${ts}] 💳 Challenge received — ${event.amount} stroops via channel ${event.channel.slice(0, 12)}...`)
+            console.log(`[${ts}]    Cumulative amount will be: ${event.cumulativeAmount} stroops`)
+            break
+          case 'signing':
+            console.log(`[${ts}] ✍️  Signing commitment...`)
+            break
+          case 'signed':
+            console.log(`[${ts}] ✅ Commitment signed (cumulative: ${event.cumulativeAmount} stroops)`)
+            break
+        }
+      },
+    }),
+  ],
+})
+
+// Make requests to the payment-gated channel server
+const SERVER_URL = process.env.SERVER_URL ?? 'http://localhost:3001'
+
+console.log(`\nRequesting ${SERVER_URL}...\n`)
+const response = await fetch(SERVER_URL)
+const data = await response.json()
+
+console.log(`\n--- Response (${response.status}) ---`)
+console.log(JSON.stringify(data, null, 2))
+
+// Make a second request to show cumulative commitment growth
+console.log(`\n\nMaking second request to show cumulative growth...\n`)
+const response2 = await fetch(SERVER_URL)
+const data2 = await response2.json()
+
+console.log(`\n--- Response 2 (${response2.status}) ---`)
+console.log(JSON.stringify(data2, null, 2))

--- a/examples/channel-close.ts
+++ b/examples/channel-close.ts
@@ -1,0 +1,103 @@
+/**
+ * Example: Close a one-way payment channel on-chain
+ *
+ * Generates a commitment signature for the given cumulative amount,
+ * then calls the contract's close() function to:
+ *   1. Transfer the committed amount to the recipient
+ *   2. Auto-refund the remaining balance to the funder
+ *
+ * Outputs the transaction hash for verification on Stellar Expert.
+ *
+ * Usage:
+ *   CHANNEL_CONTRACT=C... \
+ *   COMMITMENT_SECRET=<64-hex> \
+ *   CLOSE_SECRET=S... \
+ *   AMOUNT=2000000 \
+ *   npx tsx examples/channel-close.ts
+ */
+
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+} from '@stellar/stellar-sdk'
+import { close } from '../sdk/src/channel/server/index.js'
+import { NETWORK_PASSPHRASE, SOROBAN_RPC_URLS } from '../sdk/src/constants.js'
+
+const CHANNEL_CONTRACT = process.env.CHANNEL_CONTRACT
+const COMMITMENT_SECRET = process.env.COMMITMENT_SECRET
+const CLOSE_SECRET = process.env.CLOSE_SECRET
+const AMOUNT = BigInt(process.env.AMOUNT ?? '2000000')
+const NETWORK = 'testnet' as const
+
+if (!CHANNEL_CONTRACT?.startsWith('C') || CHANNEL_CONTRACT.length !== 56) {
+  console.error('❌ Set CHANNEL_CONTRACT to the channel contract address (C..., 56 chars)')
+  process.exit(1)
+}
+
+if (!COMMITMENT_SECRET || COMMITMENT_SECRET.length !== 64) {
+  console.error('❌ Set COMMITMENT_SECRET to the ed25519 commitment secret key (64 hex chars)')
+  process.exit(1)
+}
+
+if (!CLOSE_SECRET?.startsWith('S')) {
+  console.error('❌ Set CLOSE_SECRET to a funded Stellar secret key for signing the tx (S...)')
+  process.exit(1)
+}
+
+const commitmentKey = Keypair.fromRawEd25519Seed(Buffer.from(COMMITMENT_SECRET, 'hex'))
+const closeKey = Keypair.fromSecret(CLOSE_SECRET)
+
+console.log(`Closing channel ${CHANNEL_CONTRACT}`)
+console.log(`  Amount: ${AMOUNT} stroops (${Number(AMOUNT) / 1e7} XLM)`)
+console.log(`  Close key: ${closeKey.publicKey()}`)
+console.log('')
+
+// Step 1: Simulate prepare_commitment to get commitment bytes
+console.log('1. Simulating prepare_commitment...')
+const server = new rpc.Server(SOROBAN_RPC_URLS[NETWORK])
+const contract = new Contract(CHANNEL_CONTRACT)
+
+const account = await server.getAccount(closeKey.publicKey())
+const simTx = new TransactionBuilder(account, {
+  fee: '100',
+  networkPassphrase: NETWORK_PASSPHRASE[NETWORK],
+})
+  .addOperation(
+    contract.call('prepare_commitment', nativeToScVal(AMOUNT, { type: 'i128' })),
+  )
+  .setTimeout(30)
+  .build()
+
+const simResult = await server.simulateTransaction(simTx)
+if (!rpc.Api.isSimulationSuccess(simResult)) {
+  console.error('❌ Simulation failed:', 'error' in simResult ? simResult.error : 'unknown')
+  process.exit(1)
+}
+
+const commitmentBytes = simResult.result!.retval.bytes()
+console.log(`   Commitment: ${Buffer.from(commitmentBytes).toString('hex').slice(0, 40)}...`)
+
+// Step 2: Sign the commitment with the ed25519 key
+console.log('2. Signing commitment...')
+const signature = commitmentKey.sign(Buffer.from(commitmentBytes))
+console.log(`   Signature: ${Buffer.from(signature).toString('hex').slice(0, 40)}...`)
+
+// Step 3: Submit close transaction on-chain
+console.log('3. Submitting close transaction...')
+const txHash = await close({
+  channel: CHANNEL_CONTRACT,
+  amount: AMOUNT,
+  signature,
+  closeKey,
+  network: NETWORK,
+})
+
+console.log('')
+console.log('═══════════════════════════════════════════════════════')
+console.log('  ✅ Channel closed on-chain!')
+console.log(`  Transaction: ${txHash}`)
+console.log(`  Verify:      https://stellar.expert/explorer/testnet/tx/${txHash}`)
+console.log('═══════════════════════════════════════════════════════')

--- a/examples/channel-server.ts
+++ b/examples/channel-server.ts
@@ -1,0 +1,122 @@
+/**
+ * Example: Stellar MPP Channel Server
+ *
+ * Charges per request via off-chain one-way payment channel commitments.
+ * No on-chain transaction per payment — the recipient withdraws on-chain later.
+ *
+ * Prerequisites:
+ *   - A deployed one-way-channel contract on testnet
+ *   - The commitment public key used when deploying the channel
+ *
+ * Usage:
+ *   CHANNEL_CONTRACT=CABC... COMMITMENT_PUBKEY=b83e... npx tsx examples/channel-server.ts
+ *
+ * Then test with:
+ *   COMMITMENT_SECRET=73b5... npx tsx examples/channel-client.ts
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { StrKey } from '@stellar/stellar-sdk'
+import { Mppx, Store } from 'mppx/server'
+import { stellar } from '../sdk/src/channel/server/index.js'
+
+const PORT = Number(process.env.PORT ?? 3001)
+const CHANNEL_CONTRACT = process.env.CHANNEL_CONTRACT
+const COMMITMENT_PUBKEY = process.env.COMMITMENT_PUBKEY
+
+if (!CHANNEL_CONTRACT || !CHANNEL_CONTRACT.startsWith('C') || CHANNEL_CONTRACT.length !== 56) {
+  console.error('❌ Set CHANNEL_CONTRACT to the deployed channel contract address (C..., 56 chars)')
+  console.error('   Example: CHANNEL_CONTRACT=CBU3P5BAU6CYGPAVY7TGGGNEPCS7H73IA3L677Z3CFZSGFYB7UFK4IMS')
+  process.exit(1)
+}
+
+if (!COMMITMENT_PUBKEY || COMMITMENT_PUBKEY.length !== 64) {
+  console.error('❌ Set COMMITMENT_PUBKEY to the ed25519 public key used when deploying the channel (64 hex chars)')
+  console.error('   Example: COMMITMENT_PUBKEY=b83ee77019d9ca0aac432139fe0159ec01b5d31f58905fdc089980be05b7c5fd')
+  process.exit(1)
+}
+
+// Convert the raw ed25519 public key (hex) to a Stellar G... address for verification
+const commitmentPublicKeyG = StrKey.encodeEd25519PublicKey(Buffer.from(COMMITMENT_PUBKEY, 'hex'))
+
+const store = Store.memory()
+
+const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY ?? 'stellar-mpp-channel-demo-secret',
+  methods: [
+    stellar.channel({
+      channel: CHANNEL_CONTRACT,
+      commitmentKey: commitmentPublicKeyG,
+      store,
+      network: 'testnet',
+    }),
+  ],
+})
+
+// ---------------------------------------------------------------------------
+// Node http ↔ Web Request/Response helpers
+// ---------------------------------------------------------------------------
+
+function toWebRequest(req: IncomingMessage): Request {
+  const url = `http://${req.headers.host ?? `localhost:${PORT}`}${req.url}`
+  const headers = new Headers()
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (v) headers.set(k, Array.isArray(v) ? v.join(', ') : v)
+  }
+  return new Request(url, { method: req.method, headers })
+}
+
+async function sendWebResponse(webRes: Response, res: ServerResponse) {
+  res.statusCode = webRes.status
+  webRes.headers.forEach((v, k) => res.setHeader(k, v))
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Expose-Headers', 'WWW-Authenticate')
+  res.end(await webRes.text())
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url!, `http://localhost:${PORT}`)
+
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    res.writeHead(200, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    })
+    return res.end()
+  }
+
+  // Main MPP channel endpoint
+  const webReq = toWebRequest(req)
+  const result = await mppx.channel({
+    amount: '0.1',  // 0.1 XLM per request
+    description: 'Channel-gated API access',
+  })(webReq)
+
+  if (result.status === 402) {
+    return sendWebResponse(result.challenge, res)
+  }
+
+  return sendWebResponse(
+    result.withReceipt(
+      Response.json({
+        message: 'Payment verified via channel commitment — here is your content.',
+        timestamp: new Date().toISOString(),
+        note: 'No on-chain transaction was needed for this payment!',
+      }),
+    ),
+    res,
+  )
+})
+
+server.listen(PORT, () => {
+  console.log(`🚀 Stellar MPP Channel server running on http://localhost:${PORT}`)
+  console.log(`   Channel contract: ${CHANNEL_CONTRACT}`)
+  console.log(`   Commitment key:   ${COMMITMENT_PUBKEY.slice(0, 16)}...`)
+  console.log(`   Charging 0.1 XLM per request (off-chain commitments)`)
+})

--- a/examples/channel-server.ts
+++ b/examples/channel-server.ts
@@ -47,6 +47,7 @@ const mppx = Mppx.create({
     stellar.channel({
       channel: CHANNEL_CONTRACT,
       commitmentKey: commitmentPublicKeyG,
+      sourceAccount: process.env.SOURCE_ACCOUNT,
       store,
       network: 'testnet',
     }),

--- a/examples/channel-server.ts
+++ b/examples/channel-server.ts
@@ -2,7 +2,7 @@
  * Example: Stellar MPP Channel Server
  *
  * Charges per request via off-chain one-way payment channel commitments.
- * No on-chain transaction per payment — the recipient withdraws on-chain later.
+ * No on-chain transaction per payment — the recipient closes the channel to settle later.
  *
  * Prerequisites:
  *   - A deployed one-way-channel contract on testnet

--- a/package.json
+++ b/package.json
@@ -17,6 +17,18 @@
     "./server": {
       "types": "./dist/server/index.d.ts",
       "default": "./dist/server/index.js"
+    },
+    "./channel": {
+      "types": "./dist/channel/index.d.ts",
+      "default": "./dist/channel/index.js"
+    },
+    "./channel/client": {
+      "types": "./dist/channel/client/index.d.ts",
+      "default": "./dist/channel/client/index.js"
+    },
+    "./channel/server": {
+      "types": "./dist/channel/server/index.d.ts",
+      "default": "./dist/channel/server/index.js"
     }
   },
   "files": [
@@ -35,6 +47,7 @@
   },
   "devDependencies": {
     "@stellar/stellar-sdk": "^14.6.1",
+    "@types/node": "^25.5.0",
     "mppx": "^0.4.7",
     "tsx": "^4.21.0",
     "typescript": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "check:types": "tsc --noEmit",
     "test": "vitest",
     "demo:server": "tsx examples/server.ts",
-    "demo:client": "tsx examples/client.ts"
+    "demo:client": "tsx examples/client.ts",
+    "demo:channel-server": "tsx examples/channel-server.ts",
+    "demo:channel-client": "tsx examples/channel-client.ts"
   },
   "peerDependencies": {
     "@stellar/stellar-sdk": ">=14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@stellar/stellar-sdk':
         specifier: ^14.6.1
         version: 14.6.1
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       mppx:
         specifier: ^0.4.7
         version: 0.4.7(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.5(typescript@5.9.3)(zod@4.3.6))
@@ -26,7 +29,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -431,6 +434,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -1146,6 +1152,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -1575,6 +1584,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1583,13 +1596,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2338,6 +2351,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.18.2: {}
+
   unpipe@1.0.0: {}
 
   urijs@1.19.11: {}
@@ -2361,13 +2376,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.2.4(tsx@4.21.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2382,7 +2397,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2391,15 +2406,16 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.5.0
       fsevents: 2.3.3
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@3.2.4(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2417,9 +2433,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/sdk/src/channel/Methods.test.ts
+++ b/sdk/src/channel/Methods.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { Method } from 'mppx'
+import { channel } from './Methods.js'
+
+describe('channel method schema', () => {
+  it('has correct name and intent', () => {
+    expect(channel.name).toBe('stellar')
+    expect(channel.intent).toBe('channel')
+  })
+
+  it('is a valid Method', () => {
+    const method = Method.from(channel)
+    expect(method.name).toBe('stellar')
+    expect(method.intent).toBe('channel')
+  })
+
+  it('request schema parses amount and channel', () => {
+    const result = channel.schema.request.parse({
+      amount: '1000000',
+      channel: 'CABC123',
+    })
+    expect(result.amount).toBe('1000000')
+    expect(result.channel).toBe('CABC123')
+  })
+
+  it('request schema accepts externalId', () => {
+    const result = channel.schema.request.parse({
+      amount: '1000000',
+      channel: 'CABC123',
+      externalId: 'order-456',
+    })
+    expect(result.externalId).toBe('order-456')
+  })
+
+  it('request schema accepts methodDetails with cumulativeAmount', () => {
+    const result = channel.schema.request.parse({
+      amount: '1000000',
+      channel: 'CABC123',
+      methodDetails: {
+        reference: 'ref-001',
+        network: 'testnet',
+        cumulativeAmount: '5000000',
+      },
+    })
+    expect(result.methodDetails?.reference).toBe('ref-001')
+    expect(result.methodDetails?.network).toBe('testnet')
+    expect(result.methodDetails?.cumulativeAmount).toBe('5000000')
+  })
+
+  it('request schema allows omitting methodDetails', () => {
+    const result = channel.schema.request.parse({
+      amount: '1000000',
+      channel: 'CABC123',
+    })
+    expect(result.methodDetails).toBeUndefined()
+  })
+
+  it('credential payload accepts amount and signature', () => {
+    const result = channel.schema.credential.payload.parse({
+      amount: '3000000',
+      signature: 'deadbeef',
+    })
+    expect(result.amount).toBe('3000000')
+    expect(result.signature).toBe('deadbeef')
+  })
+})

--- a/sdk/src/channel/Methods.test.ts
+++ b/sdk/src/channel/Methods.test.ts
@@ -56,11 +56,39 @@ describe('channel method schema', () => {
   })
 
   it('credential payload accepts amount and signature', () => {
+    const validSig = 'a'.repeat(128)
     const result = channel.schema.credential.payload.parse({
       amount: '3000000',
-      signature: 'deadbeef',
+      signature: validSig,
     })
     expect(result.amount).toBe('3000000')
-    expect(result.signature).toBe('deadbeef')
+    expect(result.signature).toBe(validSig)
+  })
+
+  it('credential payload rejects non-numeric amount', () => {
+    expect(() =>
+      channel.schema.credential.payload.parse({
+        amount: 'abc',
+        signature: 'a'.repeat(128),
+      }),
+    ).toThrow()
+  })
+
+  it('credential payload rejects invalid hex signature', () => {
+    expect(() =>
+      channel.schema.credential.payload.parse({
+        amount: '1000000',
+        signature: 'not-hex',
+      }),
+    ).toThrow()
+  })
+
+  it('credential payload rejects wrong-length signature', () => {
+    expect(() =>
+      channel.schema.credential.payload.parse({
+        amount: '1000000',
+        signature: 'abcdef',
+      }),
+    ).toThrow()
   })
 })

--- a/sdk/src/channel/Methods.ts
+++ b/sdk/src/channel/Methods.ts
@@ -1,0 +1,47 @@
+import { Method } from 'mppx'
+import { z } from 'zod/mini'
+
+/**
+ * Stellar one-way payment channel intent.
+ *
+ * Instead of settling each payment on-chain, the funder signs
+ * cumulative commitments off-chain. The recipient can withdraw
+ * on-chain at any time using the latest commitment.
+ *
+ * @see https://github.com/stellar-experimental/one-way-channel
+ */
+export const channel = Method.from({
+  name: 'stellar',
+  intent: 'channel',
+  schema: {
+    credential: {
+      payload: z.object({
+        /** Cumulative amount authorised by this commitment (base units). */
+        amount: z.string(),
+        /** Ed25519 signature over the commitment bytes. */
+        signature: z.string(),
+      }),
+    },
+    request: z.object({
+      /** Incremental payment amount in base units (stroops). */
+      amount: z.string(),
+      /** On-chain channel contract address (C...). */
+      channel: z.string(),
+      /** Optional human-readable description. */
+      description: z.optional(z.string()),
+      /** Merchant-provided reconciliation ID. */
+      externalId: z.optional(z.string()),
+      /** Method-specific details injected by the server. */
+      methodDetails: z.optional(
+        z.object({
+          /** Server-generated unique tracking ID. */
+          reference: z.optional(z.string()),
+          /** Stellar network identifier ("public" | "testnet"). */
+          network: z.optional(z.string()),
+          /** Cumulative amount already committed up to this point (base units). */
+          cumulativeAmount: z.optional(z.string()),
+        }),
+      ),
+    }),
+  },
+})

--- a/sdk/src/channel/Methods.ts
+++ b/sdk/src/channel/Methods.ts
@@ -5,7 +5,7 @@ import { z } from 'zod/mini'
  * Stellar one-way payment channel intent.
  *
  * Instead of settling each payment on-chain, the funder signs
- * cumulative commitments off-chain. The recipient can withdraw
+ * cumulative commitments off-chain. The recipient can close the channel
  * on-chain at any time using the latest commitment.
  *
  * @see https://github.com/stellar-experimental/one-way-channel

--- a/sdk/src/channel/Methods.ts
+++ b/sdk/src/channel/Methods.ts
@@ -17,9 +17,9 @@ export const channel = Method.from({
     credential: {
       payload: z.object({
         /** Cumulative amount authorised by this commitment (base units). */
-        amount: z.string(),
-        /** Ed25519 signature over the commitment bytes. */
-        signature: z.string(),
+        amount: z.string().check(z.regex(/^\d+$/)),
+        /** Ed25519 signature over the commitment bytes (128 hex chars). */
+        signature: z.string().check(z.regex(/^[0-9a-f]{128}$/i)),
       }),
     },
     request: z.object({

--- a/sdk/src/channel/client/Channel.test.ts
+++ b/sdk/src/channel/client/Channel.test.ts
@@ -37,4 +37,18 @@ describe('stellar client channel', () => {
     })
     expect(typeof method.createCredential).toBe('function')
   })
+
+  it('throws if neither commitmentKey nor commitmentSecret is provided', () => {
+    expect(() => channel({} as Parameters<typeof channel>[0])).toThrow(
+      'Either commitmentKey or commitmentSecret must be provided.',
+    )
+  })
+
+  it('accepts sourceAccount parameter', () => {
+    const method = channel({
+      commitmentKey: TEST_KEYPAIR,
+      sourceAccount: Keypair.random().publicKey(),
+    })
+    expect(method.name).toBe('stellar')
+  })
 })

--- a/sdk/src/channel/client/Channel.test.ts
+++ b/sdk/src/channel/client/Channel.test.ts
@@ -1,0 +1,40 @@
+import { Keypair } from '@stellar/stellar-sdk'
+import { describe, expect, it } from 'vitest'
+import { channel } from './Channel.js'
+
+const TEST_KEYPAIR = Keypair.random()
+
+describe('stellar client channel', () => {
+  it('creates a client method with correct name and intent', () => {
+    const method = channel({ commitmentKey: TEST_KEYPAIR })
+    expect(method.name).toBe('stellar')
+    expect(method.intent).toBe('channel')
+  })
+
+  it('accepts commitmentSecret parameter', () => {
+    const method = channel({ commitmentSecret: TEST_KEYPAIR.secret() })
+    expect(method.name).toBe('stellar')
+  })
+
+  it('has createCredential function', () => {
+    const method = channel({ commitmentKey: TEST_KEYPAIR })
+    expect(typeof method.createCredential).toBe('function')
+  })
+
+  it('accepts custom rpcUrl', () => {
+    const method = channel({
+      commitmentKey: TEST_KEYPAIR,
+      rpcUrl: 'https://custom-rpc.example.com',
+    })
+    expect(method.name).toBe('stellar')
+  })
+
+  it('accepts onProgress callback', () => {
+    const events: unknown[] = []
+    const method = channel({
+      commitmentKey: TEST_KEYPAIR,
+      onProgress: (e) => events.push(e),
+    })
+    expect(typeof method.createCredential).toBe('function')
+  })
+})

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -1,0 +1,164 @@
+import {
+  Address,
+  Contract,
+  Keypair,
+  nativeToScVal,
+  rpc,
+  xdr,
+} from '@stellar/stellar-sdk'
+import { Credential, Method } from 'mppx'
+import { z } from 'zod/mini'
+import {
+  NETWORK_PASSPHRASE,
+  SOROBAN_RPC_URLS,
+  type NetworkId,
+} from '../../constants.js'
+import { channel as ChannelMethod } from '../Methods.js'
+
+/**
+ * Creates a Stellar one-way-channel method for use on the **client**.
+ *
+ * Instead of building a full Soroban transaction per payment, the client
+ * signs an ed25519 commitment authorising the recipient to withdraw up
+ * to a cumulative amount from the on-chain channel contract.
+ *
+ * @example
+ * ```ts
+ * import { Keypair } from '@stellar/stellar-sdk'
+ * import { Mppx } from 'mppx/client'
+ * import { stellar } from 'stellar-mpp-sdk/channel/client'
+ *
+ * Mppx.create({
+ *   methods: [
+ *     stellar.channel({
+ *       commitmentKey: Keypair.fromSecret('S...'),
+ *     }),
+ *   ],
+ * })
+ * ```
+ */
+export function channel(parameters: channel.Parameters) {
+  const {
+    commitmentKey: commitmentKeyParam,
+    commitmentSecret,
+    onProgress,
+    rpcUrl,
+  } = parameters
+
+  const commitmentKey =
+    commitmentKeyParam ?? Keypair.fromSecret(commitmentSecret!)
+
+  return Method.toClient(ChannelMethod, {
+    context: z.object({
+      /** Override the cumulative amount to commit. */
+      cumulativeAmount: z.optional(z.string()),
+    }),
+    async createCredential({ challenge, context }) {
+      const { request } = challenge
+      const { amount, channel: channelAddress } = request
+      const network: NetworkId =
+        (request.methodDetails?.network as NetworkId) ?? 'testnet'
+
+      // The server tells us the cumulative amount via methodDetails,
+      // or the caller can override via context.
+      const previousCumulative = BigInt(
+        request.methodDetails?.cumulativeAmount ?? '0',
+      )
+      const cumulativeAmount =
+        context?.cumulativeAmount !== undefined
+          ? BigInt(context.cumulativeAmount)
+          : previousCumulative + BigInt(amount)
+
+      onProgress?.({
+        type: 'challenge',
+        channel: channelAddress,
+        amount,
+        cumulativeAmount: cumulativeAmount.toString(),
+      })
+
+      // Call prepare_commitment on the channel contract (read-only)
+      const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
+      const networkPassphrase = NETWORK_PASSPHRASE[network]
+      const server = new rpc.Server(resolvedRpcUrl)
+
+      const contract = new Contract(channelAddress)
+      const call = contract.call(
+        'prepare_commitment',
+        nativeToScVal(cumulativeAmount, { type: 'i128' }),
+      )
+
+      // Simulate the call to get the commitment bytes
+      const account = await server.getAccount(commitmentKey.publicKey())
+      const { TransactionBuilder } = await import('@stellar/stellar-sdk')
+      const simTx = new TransactionBuilder(account, {
+        fee: '100',
+        networkPassphrase,
+      })
+        .addOperation(call)
+        .setTimeout(30)
+        .build()
+
+      const simResult = await server.simulateTransaction(simTx)
+
+      if (!rpc.Api.isSimulationSuccess(simResult)) {
+        throw new Error(
+          `Failed to simulate prepare_commitment: ${
+            'error' in simResult ? simResult.error : 'unknown error'
+          }`,
+        )
+      }
+
+      // Extract the commitment bytes from the simulation result
+      const returnValue = simResult.result?.retval
+      if (!returnValue) {
+        throw new Error('prepare_commitment returned no value')
+      }
+
+      const commitmentBytes = returnValue.bytes()
+
+      onProgress?.({ type: 'signing' })
+
+      // Sign the commitment bytes with the ed25519 commitment key
+      const signature = commitmentKey.sign(Buffer.from(commitmentBytes))
+
+      // Convert signature to hex string
+      const sigHex = signature.toString('hex')
+
+      onProgress?.({
+        type: 'signed',
+        cumulativeAmount: cumulativeAmount.toString(),
+      })
+
+      return Credential.serialize({
+        challenge,
+        payload: {
+          amount: cumulativeAmount.toString(),
+          signature: sigHex,
+        },
+      })
+    },
+  })
+}
+
+export declare namespace channel {
+  type ProgressEvent =
+    | {
+        type: 'challenge'
+        channel: string
+        amount: string
+        cumulativeAmount: string
+      }
+    | { type: 'signing' }
+    | { type: 'signed'; cumulativeAmount: string }
+
+  type Parameters = {
+    /** Ed25519 secret key (S...) for signing commitments. Provide either this or `commitmentKey`. */
+    commitmentSecret?: string
+    /** Stellar Keypair for signing commitments. Provide either this or `commitmentSecret`. */
+    commitmentKey?: Keypair
+    /** Custom Soroban RPC URL. Defaults based on network. */
+    rpcUrl?: string
+    /** Callback invoked at each lifecycle stage. */
+    onProgress?: (event: ProgressEvent) => void
+  }
+}

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -17,7 +17,7 @@ import { channel as ChannelMethod } from '../Methods.js'
  * Creates a Stellar one-way-channel method for use on the **client**.
  *
  * Instead of building a full Soroban transaction per payment, the client
- * signs an ed25519 commitment authorising the recipient to withdraw up
+ * signs an ed25519 commitment authorising the recipient to close the channel and receive up
  * to a cumulative amount from the on-chain channel contract.
  *
  * @example

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -1,10 +1,8 @@
 import {
-  Address,
   Contract,
   Keypair,
   nativeToScVal,
   rpc,
-  xdr,
 } from '@stellar/stellar-sdk'
 import { Credential, Method } from 'mppx'
 import { z } from 'zod/mini'
@@ -43,7 +41,14 @@ export function channel(parameters: channel.Parameters) {
     commitmentSecret,
     onProgress,
     rpcUrl,
+    sourceAccount,
   } = parameters
+
+  if (!commitmentKeyParam && !commitmentSecret) {
+    throw new Error(
+      'Either commitmentKey or commitmentSecret must be provided.',
+    )
+  }
 
   const commitmentKey =
     commitmentKeyParam ?? Keypair.fromSecret(commitmentSecret!)
@@ -88,7 +93,9 @@ export function channel(parameters: channel.Parameters) {
       )
 
       // Simulate the call to get the commitment bytes
-      const account = await server.getAccount(commitmentKey.publicKey())
+      const account = await server.getAccount(
+        sourceAccount ?? commitmentKey.publicKey(),
+      )
       const { TransactionBuilder } = await import('@stellar/stellar-sdk')
       const simTx = new TransactionBuilder(account, {
         fee: '100',
@@ -158,6 +165,12 @@ export declare namespace channel {
     commitmentKey?: Keypair
     /** Custom Soroban RPC URL. Defaults based on network. */
     rpcUrl?: string
+    /**
+     * Funded Stellar account address (G...) used as the source for
+     * read-only transaction simulations. If omitted, the commitment
+     * key's public key is used, which requires it to be a funded account.
+     */
+    sourceAccount?: string
     /** Callback invoked at each lifecycle stage. */
     onProgress?: (event: ProgressEvent) => void
   }

--- a/sdk/src/channel/client/Methods.ts
+++ b/sdk/src/channel/client/Methods.ts
@@ -1,0 +1,12 @@
+import { channel as channel_ } from './Channel.js'
+
+export function stellar(
+  parameters: stellar.Parameters,
+): ReturnType<typeof channel_> {
+  return channel_(parameters)
+}
+
+export namespace stellar {
+  export type Parameters = channel_.Parameters
+  export const channel = channel_
+}

--- a/sdk/src/channel/client/index.ts
+++ b/sdk/src/channel/client/index.ts
@@ -1,0 +1,3 @@
+export { channel } from './Channel.js'
+export { stellar } from './Methods.js'
+export { Mppx } from 'mppx/client'

--- a/sdk/src/channel/index.ts
+++ b/sdk/src/channel/index.ts
@@ -1,0 +1,1 @@
+export { channel } from './Methods.js'

--- a/sdk/src/channel/integration.test.ts
+++ b/sdk/src/channel/integration.test.ts
@@ -1,0 +1,115 @@
+import { Keypair } from '@stellar/stellar-sdk'
+import { Challenge, Credential, Store } from 'mppx'
+import { describe, expect, it } from 'vitest'
+import { channel as serverChannel } from './server/Channel.js'
+import { channel as clientChannel } from './client/Channel.js'
+
+const COMMITMENT_KEY = Keypair.random()
+const CHANNEL_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM'
+
+function mockChallenge(overrides: Record<string, unknown> = {}) {
+  return Challenge.from({
+    id: `test-${crypto.randomUUID()}`,
+    realm: 'localhost',
+    method: 'stellar',
+    intent: 'channel',
+    request: {
+      amount: '1000000',
+      channel: CHANNEL_ADDRESS,
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'testnet',
+        cumulativeAmount: '0',
+      },
+      ...overrides,
+    },
+  })
+}
+
+describe('channel server creation', () => {
+  it('creates method with defaults', () => {
+    const method = serverChannel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+    })
+    expect(method.name).toBe('stellar')
+    expect(method.intent).toBe('channel')
+    expect(typeof method.verify).toBe('function')
+  })
+
+  it('returns 402 challenge when no credential provided', async () => {
+    const { Mppx } = await import('mppx/server')
+    const mppx = Mppx.create({
+      secretKey: 'test-secret-key-for-mppx',
+      methods: [
+        serverChannel({
+          channel: CHANNEL_ADDRESS,
+          commitmentKey: COMMITMENT_KEY.publicKey(),
+        }),
+      ],
+    })
+
+    const handler = mppx.channel({ amount: '1' })
+    const result = await handler(new Request('http://localhost/test'))
+    expect(result.status).toBe(402)
+  })
+})
+
+describe('channel client creation', () => {
+  it('creates method with commitmentKey', () => {
+    const method = clientChannel({ commitmentKey: COMMITMENT_KEY })
+    expect(method.name).toBe('stellar')
+    expect(method.intent).toBe('channel')
+    expect(typeof method.createCredential).toBe('function')
+  })
+
+  it('tracks onProgress events', () => {
+    const events: unknown[] = []
+    const method = clientChannel({
+      commitmentKey: COMMITMENT_KEY,
+      onProgress: (e) => events.push(e),
+    })
+    expect(typeof method.createCredential).toBe('function')
+  })
+})
+
+describe('channel replay protection', () => {
+  it('store tracks used challenge IDs', async () => {
+    const store = Store.memory()
+
+    const key = 'stellar:challenge:test-channel-id-123'
+    const before = await store.get(key)
+    expect(before).toBeNull()
+
+    await store.put(key, { usedAt: new Date().toISOString() })
+
+    const after = await store.get(key)
+    expect(after).not.toBeNull()
+    expect((after as { usedAt: string }).usedAt).toBeDefined()
+  })
+
+  it('store tracks cumulative amounts', async () => {
+    const store = Store.memory()
+
+    const key = `stellar:channel:cumulative:${CHANNEL_ADDRESS}`
+    await store.put(key, { amount: '5000000' })
+
+    const stored = await store.get(key)
+    expect(stored).not.toBeNull()
+    expect((stored as { amount: string }).amount).toBe('5000000')
+  })
+})
+
+describe('channel credential serialization', () => {
+  it('credential schema accepts commitment payload', () => {
+    const challenge = mockChallenge()
+    const serialized = Credential.serialize({
+      challenge,
+      payload: {
+        amount: '1000000',
+        signature: 'deadbeef1234567890abcdef',
+      },
+    })
+    expect(serialized).toContain('Payment')
+  })
+})

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -67,4 +67,13 @@ describe('stellar server channel', () => {
     })
     expect(method.name).toBe('stellar')
   })
+
+  it('accepts sourceAccount parameter', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+      sourceAccount: Keypair.random().publicKey(),
+    })
+    expect(method.name).toBe('stellar')
+  })
 })

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -1,0 +1,70 @@
+import { Keypair } from '@stellar/stellar-sdk'
+import { Store } from 'mppx'
+import { describe, expect, it } from 'vitest'
+import { channel } from './Channel.js'
+
+const COMMITMENT_KEY = Keypair.random()
+const CHANNEL_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM'
+
+describe('stellar server channel', () => {
+  it('creates a server method with correct name and intent', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+    })
+    expect(method.name).toBe('stellar')
+    expect(method.intent).toBe('channel')
+  })
+
+  it('has a verify function', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+    })
+    expect(typeof method.verify).toBe('function')
+  })
+
+  it('accepts store for replay protection', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+      store: Store.memory(),
+    })
+    expect(method.name).toBe('stellar')
+  })
+
+  it('accepts custom network', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+      network: 'public',
+    })
+    expect(method.name).toBe('stellar')
+  })
+
+  it('accepts custom rpcUrl', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+      rpcUrl: 'https://custom.rpc.example.com',
+    })
+    expect(method.name).toBe('stellar')
+  })
+
+  it('accepts commitmentKey as Keypair', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+    })
+    expect(method.name).toBe('stellar')
+  })
+
+  it('accepts custom decimals', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+      decimals: 6,
+    })
+    expect(method.name).toBe('stellar')
+  })
+})

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -1,10 +1,117 @@
 import { Keypair } from '@stellar/stellar-sdk'
-import { Store } from 'mppx'
-import { describe, expect, it } from 'vitest'
-import { channel } from './Channel.js'
+import { Challenge, Credential, Store } from 'mppx'
+import { describe, expect, it, vi } from 'vitest'
+
+// Hoisted mock stubs — accessible inside the vi.mock factory
+const mockGetAccount = vi.fn()
+const mockSimulateTransaction = vi.fn()
+
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>()
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: vi.fn().mockImplementation(() => ({
+        getAccount: mockGetAccount,
+        simulateTransaction: mockSimulateTransaction,
+      })),
+    },
+  }
+})
+
+// Re-import after mock is set up
+const { channel } = await import('./Channel.js')
+
+// Default: getAccount returns a minimal account stub with a valid public key
+const MOCK_SOURCE_KEY = Keypair.random()
+mockGetAccount.mockResolvedValue({
+  accountId: () => MOCK_SOURCE_KEY.publicKey(),
+  sequenceNumber: () => '0',
+  sequence: () => '0',
+  incrementSequenceNumber: () => {},
+})
 
 const COMMITMENT_KEY = Keypair.random()
-const CHANNEL_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM'
+const CHANNEL_ADDRESS = 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526'
+
+/**
+ * Build a fake credential for testing verify().
+ */
+function makeCredential(opts: {
+  amount: string
+  challengeAmount?: string
+  cumulativeAmount?: string
+  signature?: string
+}) {
+  const challenge = Challenge.from({
+    id: `test-${crypto.randomUUID()}`,
+    realm: 'localhost',
+    method: 'stellar',
+    intent: 'channel',
+    request: {
+      amount: opts.challengeAmount ?? opts.amount,
+      channel: CHANNEL_ADDRESS,
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'testnet',
+        cumulativeAmount: opts.cumulativeAmount ?? '0',
+      },
+    },
+  })
+  return Credential.from({
+    challenge,
+    payload: {
+      amount: opts.amount,
+      signature: opts.signature ?? 'a'.repeat(128),
+    },
+  })
+}
+
+/** Build a credential with a real ed25519 signature over `commitmentBytes`. */
+function makeSignedCredential(opts: {
+  commitmentBytes: Buffer
+  cumulativeAmount: bigint
+  challengeAmount: string
+  previousCumulative?: string
+}) {
+  const sig = COMMITMENT_KEY.sign(opts.commitmentBytes)
+  const sigHex = Buffer.from(sig).toString('hex')
+  const challenge = Challenge.from({
+    id: `test-${crypto.randomUUID()}`,
+    realm: 'localhost',
+    method: 'stellar',
+    intent: 'channel',
+    request: {
+      amount: opts.challengeAmount,
+      channel: CHANNEL_ADDRESS,
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'testnet',
+        cumulativeAmount: opts.previousCumulative ?? '0',
+      },
+    },
+  })
+  return Credential.from({
+    challenge,
+    payload: {
+      amount: opts.cumulativeAmount.toString(),
+      signature: sigHex,
+    },
+  })
+}
+
+/** Create a successful simulation result returning given commitment bytes. */
+function successSimResult(commitmentBytes: Buffer) {
+  return {
+    result: {
+      retval: {
+        bytes: () => commitmentBytes,
+      },
+    },
+    transactionData: 'mock',
+  }
+}
 
 describe('stellar server channel', () => {
   it('creates a server method with correct name and intent', () => {
@@ -75,5 +182,214 @@ describe('stellar server channel', () => {
       sourceAccount: Keypair.random().publicKey(),
     })
     expect(method.name).toBe('stellar')
+  })
+})
+
+describe('stellar server channel verification', () => {
+  it('rejects underpayment (commitment does not cover requested amount)', async () => {
+    // Commitment = 500000, but challenge requests 1000000 → should reject
+    const credential = makeCredential({
+      amount: '500000',
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('does not cover the requested amount')
+  })
+
+  it('rejects commitment below previous cumulative', async () => {
+    const store = Store.memory()
+    const cumulativeKey = `stellar:channel:cumulative:${CHANNEL_ADDRESS}`
+    await store.put(cumulativeKey, { amount: '5000000' })
+
+    // Commitment = 3000000, previous cumulative = 5000000 → reject
+    const credential = makeCredential({
+      amount: '3000000',
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      store,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('is less than previous cumulative')
+  })
+
+  it('rejects invalid hex signature', async () => {
+    const credential = makeCredential({
+      amount: '1000000',
+      challengeAmount: '1000000',
+      signature: 'zz-not-hex!!',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Invalid signature')
+  })
+
+  it('rejects wrong-length signature', async () => {
+    const credential = makeCredential({
+      amount: '1000000',
+      challengeAmount: '1000000',
+      signature: 'abcdef12', // only 8 hex chars, need 128
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Invalid signature length')
+  })
+
+  it('rejects invalid ed25519 signature (bad sig, valid hex)', async () => {
+    const commitmentBytes = Buffer.from('test-commitment-data')
+    mockSimulateTransaction.mockResolvedValueOnce(
+      successSimResult(commitmentBytes),
+    )
+
+    // Use a valid-length hex string that is NOT a valid signature
+    const credential = makeCredential({
+      amount: '1000000',
+      challengeAmount: '1000000',
+      signature: 'ab'.repeat(64), // 128 hex chars, 64 bytes, but wrong sig
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Commitment signature verification failed')
+  })
+
+  it('accepts valid commitment and updates cumulative in store', async () => {
+    const commitmentBytes = Buffer.from('valid-commitment-bytes')
+    mockSimulateTransaction.mockResolvedValueOnce(
+      successSimResult(commitmentBytes),
+    )
+
+    const store = Store.memory()
+    const cumulativeKey = `stellar:channel:cumulative:${CHANNEL_ADDRESS}`
+
+    const credential = makeSignedCredential({
+      commitmentBytes,
+      cumulativeAmount: 1000000n,
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      store,
+    })
+
+    const receipt = await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+
+    expect(receipt.status).toBe('success')
+
+    // Verify cumulative was updated in the store
+    const stored = (await store.get(cumulativeKey)) as { amount: string }
+    expect(stored.amount).toBe('1000000')
+  })
+
+  it('does not update cumulative on verification failure', async () => {
+    const store = Store.memory()
+    const cumulativeKey = `stellar:channel:cumulative:${CHANNEL_ADDRESS}`
+
+    // Credential that will fail (underpayment)
+    const credential = makeCredential({
+      amount: '500000',
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      store,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow()
+
+    // Store should not have been updated
+    const stored = await store.get(cumulativeKey)
+    expect(stored).toBeNull()
+  })
+
+  it('rejects replay of same challenge ID', async () => {
+    const commitmentBytes = Buffer.from('replay-test-bytes')
+    mockSimulateTransaction.mockResolvedValue(
+      successSimResult(commitmentBytes),
+    )
+
+    const store = Store.memory()
+
+    const credential = makeSignedCredential({
+      commitmentBytes,
+      cumulativeAmount: 1000000n,
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      store,
+    })
+
+    // First call should succeed
+    await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+
+    // Same credential (same challenge.id) should be rejected
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Replay rejected')
   })
 })

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -21,7 +21,7 @@ import { channel as ChannelMethod } from '../Methods.js'
  * The server:
  * 1. Issues challenges with the channel contract address and cumulative amount
  * 2. Verifies commitment signatures against the channel's commitment key
- * 3. Optionally withdraws accumulated funds on-chain
+ * 3. Optionally closes the channel and settles funds on-chain
  *
  * @example
  * ```ts
@@ -237,18 +237,20 @@ export function channel(parameters: channel.Parameters) {
 }
 
 /**
- * Withdraw funds from the channel contract on-chain using the latest
- * commitment. This is a server-side administrative operation.
+ * Close the channel contract on-chain using a signed commitment.
+ * Transfers the committed amount to the recipient and auto-refunds
+ * the remaining balance to the funder. This is a server-side
+ * administrative operation.
  */
-export async function withdraw(parameters: {
+export async function close(parameters: {
   /** Channel contract address. */
   channel: string
-  /** Cumulative amount to withdraw. */
+  /** Commitment amount to close with. */
   amount: bigint
   /** Ed25519 signature for the commitment. */
   signature: Uint8Array
-  /** Keypair to sign the withdrawal transaction. */
-  withdrawKey: Keypair
+  /** Keypair to sign the close transaction. */
+  closeKey: Keypair
   /** Network identifier. */
   network?: NetworkId
   /** Custom RPC URL. */
@@ -258,7 +260,7 @@ export async function withdraw(parameters: {
     channel: channelAddress,
     amount,
     signature,
-    withdrawKey,
+    closeKey,
     network = 'testnet',
     rpcUrl,
   } = parameters
@@ -268,23 +270,23 @@ export async function withdraw(parameters: {
   const server = new rpc.Server(resolvedRpcUrl)
 
   const contract = new Contract(channelAddress)
-  const withdrawOp = contract.call(
-    'withdraw',
+  const closeOp = contract.call(
+    'close',
     nativeToScVal(amount, { type: 'i128' }),
     nativeToScVal(Buffer.from(signature), { type: 'bytes' }),
   )
 
-  const account = await server.getAccount(withdrawKey.publicKey())
+  const account = await server.getAccount(closeKey.publicKey())
   const tx = new TransactionBuilder(account, {
     fee: '100',
     networkPassphrase,
   })
-    .addOperation(withdrawOp)
+    .addOperation(closeOp)
     .setTimeout(180)
     .build()
 
   const prepared = await server.prepareTransaction(tx)
-  prepared.sign(withdrawKey)
+  prepared.sign(closeKey)
 
   const result = await server.sendTransaction(prepared)
 
@@ -304,7 +306,7 @@ export async function withdraw(parameters: {
 
   if (txResult.status !== 'SUCCESS') {
     throw new ChannelVerificationError(
-      `Withdraw transaction failed: ${txResult.status}`,
+      `Close transaction failed: ${txResult.status}`,
       { hash: result.hash, status: txResult.status },
     )
   }

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -1,0 +1,316 @@
+import {
+  Address,
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+} from '@stellar/stellar-sdk'
+import { Method, Receipt, Store } from 'mppx'
+import {
+  DEFAULT_DECIMALS,
+  NETWORK_PASSPHRASE,
+  SOROBAN_RPC_URLS,
+  type NetworkId,
+} from '../../constants.js'
+import { toBaseUnits } from '../../Methods.js'
+import { channel as ChannelMethod } from '../Methods.js'
+
+/**
+ * Creates a Stellar one-way-channel method for use on the **server**.
+ *
+ * The server:
+ * 1. Issues challenges with the channel contract address and cumulative amount
+ * 2. Verifies commitment signatures against the channel's commitment key
+ * 3. Optionally withdraws accumulated funds on-chain
+ *
+ * @example
+ * ```ts
+ * import { stellar } from 'stellar-mpp-sdk/channel/server'
+ * import { Mppx } from 'mppx/server'
+ *
+ * const mppx = Mppx.create({
+ *   secretKey: 'my-secret',
+ *   methods: [
+ *     stellar.channel({
+ *       channel: 'C...',          // on-chain channel contract
+ *       commitmentKey: 'GABC...', // ed25519 public key for verifying commitments
+ *     }),
+ *   ],
+ * })
+ * ```
+ */
+export function channel(parameters: channel.Parameters) {
+  const {
+    channel: channelAddress,
+    commitmentKey: commitmentKeyParam,
+    decimals = DEFAULT_DECIMALS,
+    network = 'testnet',
+    rpcUrl,
+    store,
+    withdrawKey,
+  } = parameters
+
+  const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
+  const networkPassphrase = NETWORK_PASSPHRASE[network]
+  const server = new rpc.Server(resolvedRpcUrl)
+
+  // Parse the commitment public key (accepts G... string or raw hex)
+  const commitmentKeypair = (() => {
+    if (typeof commitmentKeyParam === 'string') {
+      // Could be a Stellar public key (G...) — create a verify-only Keypair
+      return Keypair.fromPublicKey(commitmentKeyParam)
+    }
+    return commitmentKeyParam
+  })()
+
+  // Track cumulative amounts per channel in the store
+  const cumulativeKey = `stellar:channel:cumulative:${channelAddress}`
+
+  return Method.toServer(ChannelMethod, {
+    defaults: {
+      channel: channelAddress,
+    },
+    async request({ request }) {
+      // Retrieve current cumulative amount from store
+      let currentCumulative = '0'
+      if (store) {
+        const stored = await store.get(cumulativeKey)
+        if (stored && typeof stored === 'object' && 'amount' in stored) {
+          currentCumulative = (stored as { amount: string }).amount
+        }
+      }
+
+      return {
+        ...request,
+        amount: toBaseUnits(request.amount, decimals),
+        methodDetails: {
+          ...request.methodDetails,
+          reference: crypto.randomUUID(),
+          network,
+          cumulativeAmount: currentCumulative,
+        },
+      }
+    },
+    async verify({ credential }) {
+      const { challenge } = credential
+      const { request: challengeRequest } = challenge
+
+      // Replay protection
+      if (store) {
+        const replayKey = `stellar:challenge:${challenge.id}`
+        const existing = await store.get(replayKey)
+        if (existing) {
+          throw new Error('Challenge already used. Replay rejected.')
+        }
+        await store.put(replayKey, { usedAt: new Date().toISOString() })
+      }
+
+      const payload = credential.payload
+      const commitmentAmount = BigInt(payload.amount)
+      const signatureHex = payload.signature
+      const signatureBytes = Buffer.from(signatureHex, 'hex')
+
+      // Retrieve the previous cumulative amount
+      let previousCumulative = 0n
+      if (store) {
+        const stored = await store.get(cumulativeKey)
+        if (stored && typeof stored === 'object' && 'amount' in stored) {
+          previousCumulative = BigInt((stored as { amount: string }).amount)
+        }
+      }
+
+      // The new cumulative must be >= previous cumulative
+      if (commitmentAmount < previousCumulative) {
+        throw new ChannelVerificationError(
+          `Commitment amount ${commitmentAmount} is less than previous cumulative ${previousCumulative}.`,
+          {
+            commitmentAmount: commitmentAmount.toString(),
+            previousCumulative: previousCumulative.toString(),
+          },
+        )
+      }
+
+      // Verify: call prepare_commitment on the channel contract to
+      // reconstruct the expected commitment bytes, then verify the
+      // ed25519 signature.
+      const contract = new Contract(channelAddress)
+      const call = contract.call(
+        'prepare_commitment',
+        nativeToScVal(commitmentAmount, { type: 'i128' }),
+      )
+
+      const account = await server.getAccount(
+        commitmentKeypair.publicKey(),
+      )
+      const simTx = new TransactionBuilder(account, {
+        fee: '100',
+        networkPassphrase,
+      })
+        .addOperation(call)
+        .setTimeout(30)
+        .build()
+
+      const simResult = await server.simulateTransaction(simTx)
+
+      if (!rpc.Api.isSimulationSuccess(simResult)) {
+        throw new ChannelVerificationError(
+          'Failed to simulate prepare_commitment for verification.',
+          {
+            error:
+              'error' in simResult
+                ? String(simResult.error)
+                : 'unknown',
+          },
+        )
+      }
+
+      const returnValue = simResult.result?.retval
+      if (!returnValue) {
+        throw new ChannelVerificationError(
+          'prepare_commitment returned no value.',
+          {},
+        )
+      }
+
+      const commitmentBytes = returnValue.bytes()
+
+      // Verify the ed25519 signature
+      const valid = commitmentKeypair.verify(
+        Buffer.from(commitmentBytes),
+        signatureBytes,
+      )
+
+      if (!valid) {
+        throw new ChannelVerificationError(
+          'Commitment signature verification failed.',
+          {
+            amount: commitmentAmount.toString(),
+            channel: channelAddress,
+          },
+        )
+      }
+
+      // Update cumulative amount in store
+      if (store) {
+        await store.put(cumulativeKey, {
+          amount: commitmentAmount.toString(),
+        })
+      }
+
+      // Calculate the incremental payment
+      const incrementalAmount = commitmentAmount - previousCumulative
+
+      return Receipt.from({
+        method: 'stellar',
+        reference: challengeRequest.methodDetails?.reference ?? challenge.id,
+        status: 'success',
+        timestamp: new Date().toISOString(),
+      })
+    },
+  })
+}
+
+/**
+ * Withdraw funds from the channel contract on-chain using the latest
+ * commitment. This is a server-side administrative operation.
+ */
+export async function withdraw(parameters: {
+  /** Channel contract address. */
+  channel: string
+  /** Cumulative amount to withdraw. */
+  amount: bigint
+  /** Ed25519 signature for the commitment. */
+  signature: Uint8Array
+  /** Keypair to sign the withdrawal transaction. */
+  withdrawKey: Keypair
+  /** Network identifier. */
+  network?: NetworkId
+  /** Custom RPC URL. */
+  rpcUrl?: string
+}): Promise<string> {
+  const {
+    channel: channelAddress,
+    amount,
+    signature,
+    withdrawKey,
+    network = 'testnet',
+    rpcUrl,
+  } = parameters
+
+  const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
+  const networkPassphrase = NETWORK_PASSPHRASE[network]
+  const server = new rpc.Server(resolvedRpcUrl)
+
+  const contract = new Contract(channelAddress)
+  const withdrawOp = contract.call(
+    'withdraw',
+    nativeToScVal(amount, { type: 'i128' }),
+    nativeToScVal(Buffer.from(signature), { type: 'bytes' }),
+  )
+
+  const account = await server.getAccount(withdrawKey.publicKey())
+  const tx = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase,
+  })
+    .addOperation(withdrawOp)
+    .setTimeout(180)
+    .build()
+
+  const prepared = await server.prepareTransaction(tx)
+  prepared.sign(withdrawKey)
+
+  const result = await server.sendTransaction(prepared)
+
+  let txResult = await server.getTransaction(result.hash)
+  while (txResult.status === 'NOT_FOUND') {
+    await new Promise((r) => setTimeout(r, 1000))
+    txResult = await server.getTransaction(result.hash)
+  }
+
+  if (txResult.status !== 'SUCCESS') {
+    throw new ChannelVerificationError(
+      `Withdraw transaction failed: ${txResult.status}`,
+      { hash: result.hash, status: txResult.status },
+    )
+  }
+
+  return result.hash
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export declare namespace channel {
+  type Parameters = {
+    /** On-chain channel contract address (C...). */
+    channel: string
+    /**
+     * Ed25519 public key for verifying commitment signatures.
+     * Accepts a Stellar public key string (G...) or a Keypair instance.
+     */
+    commitmentKey: string | Keypair
+    /** Number of decimal places for amount conversion. @default 7 */
+    decimals?: number
+    /** Stellar network. @default 'testnet' */
+    network?: NetworkId
+    /** Custom Soroban RPC URL. */
+    rpcUrl?: string
+    /** Store for replay protection and cumulative amount tracking. */
+    store?: Store.Store
+    /** Keypair for signing on-chain withdraw transactions. */
+    withdrawKey?: Keypair
+  }
+}
+
+class ChannelVerificationError extends Error {
+  details: Record<string, string>
+
+  constructor(message: string, details: Record<string, string>) {
+    super(message)
+    this.name = 'ChannelVerificationError'
+    this.details = details
+  }
+}

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -1,5 +1,4 @@
 import {
-  Address,
   Contract,
   Keypair,
   TransactionBuilder,
@@ -47,18 +46,17 @@ export function channel(parameters: channel.Parameters) {
     decimals = DEFAULT_DECIMALS,
     network = 'testnet',
     rpcUrl,
+    sourceAccount,
     store,
-    withdrawKey,
   } = parameters
 
   const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
   const networkPassphrase = NETWORK_PASSPHRASE[network]
   const server = new rpc.Server(resolvedRpcUrl)
 
-  // Parse the commitment public key (accepts G... string or raw hex)
+  // Parse the commitment public key (accepts G... Stellar public key string or Keypair)
   const commitmentKeypair = (() => {
     if (typeof commitmentKeyParam === 'string') {
-      // Could be a Stellar public key (G...) — create a verify-only Keypair
       return Keypair.fromPublicKey(commitmentKeyParam)
     }
     return commitmentKeyParam
@@ -109,6 +107,20 @@ export function channel(parameters: channel.Parameters) {
       const payload = credential.payload
       const commitmentAmount = BigInt(payload.amount)
       const signatureHex = payload.signature
+
+      // Validate hex signature format
+      if (!/^[0-9a-f]+$/i.test(signatureHex) || signatureHex.length % 2 !== 0) {
+        throw new ChannelVerificationError(
+          'Invalid signature: not a valid hex string.',
+          { signature: signatureHex },
+        )
+      }
+      if (signatureHex.length !== 128) {
+        throw new ChannelVerificationError(
+          `Invalid signature length: expected 128 hex chars (64 bytes), got ${signatureHex.length}.`,
+          { length: String(signatureHex.length) },
+        )
+      }
       const signatureBytes = Buffer.from(signatureHex, 'hex')
 
       // Retrieve the previous cumulative amount
@@ -131,6 +143,19 @@ export function channel(parameters: channel.Parameters) {
         )
       }
 
+      // The commitment must cover the requested amount
+      const requestedAmount = BigInt(challengeRequest.amount)
+      if (commitmentAmount < previousCumulative + requestedAmount) {
+        throw new ChannelVerificationError(
+          `Commitment amount ${commitmentAmount} does not cover the requested amount ${requestedAmount} (previous cumulative: ${previousCumulative}).`,
+          {
+            commitmentAmount: commitmentAmount.toString(),
+            requestedAmount: requestedAmount.toString(),
+            previousCumulative: previousCumulative.toString(),
+          },
+        )
+      }
+
       // Verify: call prepare_commitment on the channel contract to
       // reconstruct the expected commitment bytes, then verify the
       // ed25519 signature.
@@ -141,7 +166,7 @@ export function channel(parameters: channel.Parameters) {
       )
 
       const account = await server.getAccount(
-        commitmentKeypair.publicKey(),
+        sourceAccount ?? commitmentKeypair.publicKey(),
       )
       const simTx = new TransactionBuilder(account, {
         fee: '100',
@@ -263,8 +288,16 @@ export async function withdraw(parameters: {
 
   const result = await server.sendTransaction(prepared)
 
+  const MAX_POLL_ATTEMPTS = 60
   let txResult = await server.getTransaction(result.hash)
+  let attempts = 0
   while (txResult.status === 'NOT_FOUND') {
+    if (++attempts >= MAX_POLL_ATTEMPTS) {
+      throw new ChannelVerificationError(
+        `Transaction not found after ${MAX_POLL_ATTEMPTS} attempts.`,
+        { hash: result.hash },
+      )
+    }
     await new Promise((r) => setTimeout(r, 1000))
     txResult = await server.getTransaction(result.hash)
   }
@@ -298,10 +331,14 @@ export declare namespace channel {
     network?: NetworkId
     /** Custom Soroban RPC URL. */
     rpcUrl?: string
+    /**
+     * Funded Stellar account address (G...) used as the source for
+     * read-only transaction simulations. If omitted, the commitment
+     * key's public key is used, which requires it to be a funded account.
+     */
+    sourceAccount?: string
     /** Store for replay protection and cumulative amount tracking. */
     store?: Store.Store
-    /** Keypair for signing on-chain withdraw transactions. */
-    withdrawKey?: Keypair
   }
 }
 

--- a/sdk/src/channel/server/Methods.ts
+++ b/sdk/src/channel/server/Methods.ts
@@ -1,0 +1,12 @@
+import { channel as channel_ } from './Channel.js'
+
+export function stellar(
+  parameters: stellar.Parameters,
+): ReturnType<typeof channel_> {
+  return stellar.channel(parameters)
+}
+
+export namespace stellar {
+  export type Parameters = channel_.Parameters
+  export const channel = channel_
+}

--- a/sdk/src/channel/server/index.ts
+++ b/sdk/src/channel/server/index.ts
@@ -1,0 +1,3 @@
+export { channel, withdraw } from './Channel.js'
+export { stellar } from './Methods.js'
+export { Expires, Mppx, Store } from 'mppx/server'

--- a/sdk/src/channel/server/index.ts
+++ b/sdk/src/channel/server/index.ts
@@ -1,3 +1,3 @@
-export { channel, withdraw } from './Channel.js'
+export { channel, close } from './Channel.js'
 export { stellar } from './Methods.js'
 export { Expires, Mppx, Store } from 'mppx/server'

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * as Methods from './Methods.js'
+export * as ChannelMethods from './channel/Methods.js'
 export {
   DEFAULT_DECIMALS,
   DEFAULT_FEE,


### PR DESCRIPTION
## Summary

Adds support for [one-way payment channels](https://github.com/stellar-experimental/one-way-channel) alongside the existing SAC charge method. Enables high-frequency off-chain micro-payments via cumulative ed25519 commitment signatures — no on-chain transaction per payment.

## What's new

### Channel method
- **Method schema** — new stellar/channel intent with commitment-based credentials (amount + ed25519 signature)
- **Client** — calls prepare_commitment on the channel contract (read-only simulate), signs commitment bytes with ed25519 key
- **Server** — verifies commitment signatures, tracks cumulative amounts via Store, includes withdraw() helper for on-chain settlement

### Demo and examples
- examples/channel-server.ts — channel payment server
- examples/channel-client.ts — channel client with progress events
- demo/run-channel.sh — all-in-one channel demo script

### Deployed testnet contract
A test channel contract is deployed at:
- Contract: CBU3P5BAU6CYGPAVY7TGGGNEPCS7H73IA3L677Z3CFZSGFYB7UFK4IMS
- Token: Native XLM
- Deposit: 1 XLM

## How it works

No on-chain transactions during payments. Client signs cumulative commitments off-chain. Server verifies signature and serves resource. Server withdraws accumulated funds on-chain when convenient.

## Changes
- New: sdk/src/channel/ — Methods, client, server implementations + tests
- Modified: sdk/src/index.ts — added ChannelMethods export
- Modified: package.json — added channel export paths + demo scripts + @types/node
- Updated: README.md, demo/README.md — full documentation

## Tests
9 test files, 74 tests — all passing (48 existing + 26 new).
