### PR TITLE
fix: address Copilot review comments from PR #1

### DIFF
--- a/demo/run.sh
+++ b/demo/run.sh
@@ -43,7 +43,7 @@ echo ""
 PORT=${PORT:-3000}
 
 # Kill any existing process on the port
-if lsof -ti:$PORT &>/dev/null; then
+if command -v lsof &>/dev/null && lsof -ti:$PORT &>/dev/null; then
   echo "⚠ Port $PORT in use — freeing it..."
   lsof -ti:$PORT | xargs kill -9 2>/dev/null
   sleep 1

--- a/sdk/src/server/Charge.test.ts
+++ b/sdk/src/server/Charge.test.ts
@@ -1,10 +1,167 @@
-import { Keypair } from '@stellar/stellar-sdk'
-import { Store } from 'mppx'
-import { describe, expect, it } from 'vitest'
+import {
+  Account,
+  Address,
+  Keypair,
+  Networks,
+  StrKey,
+  Transaction,
+  TransactionBuilder,
+  xdr,
+} from '@stellar/stellar-sdk'
+import { Challenge, Credential, Store } from 'mppx'
+import { describe, expect, it, vi } from 'vitest'
 import { USDC_SAC_TESTNET } from '../constants.js'
-import { charge } from './Charge.js'
+
+// Hoisted mock stubs for rpc.Server
+const mockGetTransaction = vi.fn()
+const mockSendTransaction = vi.fn()
+
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>()
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: vi.fn().mockImplementation(() => ({
+        getTransaction: mockGetTransaction,
+        sendTransaction: mockSendTransaction,
+      })),
+    },
+  }
+})
+
+const { charge } = await import('./Charge.js')
 
 const RECIPIENT = Keypair.random().publicKey()
+
+// ---------------------------------------------------------------------------
+// Helpers to build SAC transfer transactions for tests
+// ---------------------------------------------------------------------------
+
+/** Encode a contract ID from raw bytes. */
+function makeContractId(seed = 1): string {
+  return StrKey.encodeContract(Buffer.alloc(32, seed))
+}
+
+/** Build a Transaction containing an invokeHostFunction(transfer) op. */
+function buildSacTransferTx(opts: {
+  sender: Keypair
+  recipientPubkey: string
+  contractId: string
+  amount: bigint
+}) {
+  const contractAddr = new Address(opts.contractId).toScAddress()
+  const fromAddr = new Address(opts.sender.publicKey()).toScVal()
+  const toAddr = new Address(opts.recipientPubkey).toScVal()
+  const amountScVal = xdr.ScVal.scvI128(
+    new xdr.Int128Parts({
+      lo: xdr.Uint64.fromString(opts.amount.toString()),
+      hi: xdr.Int64.fromString('0'),
+    }),
+  )
+
+  const invokeArgs = new xdr.InvokeContractArgs({
+    contractAddress: contractAddr,
+    functionName: 'transfer',
+    args: [fromAddr, toAddr, amountScVal],
+  })
+
+  const hostFn = xdr.HostFunction.hostFunctionTypeInvokeContract(invokeArgs)
+
+  const invokeHostFnOp = new xdr.InvokeHostFunctionOp({
+    hostFunction: hostFn,
+    auth: [],
+  })
+
+  const op = new xdr.Operation({
+    sourceAccount: null,
+    body: xdr.OperationBody.invokeHostFunction(invokeHostFnOp),
+  })
+
+  // Build a stub tx to get the envelope, then replace its operations
+  const account = new Account(opts.sender.publicKey(), '0')
+  const stubTx = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase: Networks.TESTNET,
+  })
+    .setTimeout(30)
+    .build()
+
+  const envelope = xdr.TransactionEnvelope.fromXDR(stubTx.toXDR(), 'base64')
+  envelope.v1().tx().operations([op])
+
+  return new Transaction(envelope, Networks.TESTNET)
+}
+
+/** Build a mock successful transaction result with envelope XDR. */
+function mockTxResult(tx: ReturnType<typeof buildSacTransferTx>) {
+  return {
+    status: 'SUCCESS' as const,
+    envelopeXdr: tx.toXDR(),
+  }
+}
+
+/** Build a credential for the 'signature' verification path. */
+function makeSignatureCredential(opts: {
+  hash: string
+  amount: string
+  currency: string
+  recipient: string
+}) {
+  const challenge = Challenge.from({
+    id: `test-${crypto.randomUUID()}`,
+    realm: 'localhost',
+    method: 'stellar',
+    intent: 'charge',
+    request: {
+      amount: opts.amount,
+      currency: opts.currency,
+      recipient: opts.recipient,
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'testnet',
+      },
+    },
+  })
+  return Credential.from({
+    challenge,
+    payload: {
+      type: 'signature',
+      hash: opts.hash,
+    },
+  })
+}
+
+/** Build a credential for the 'transaction' verification path. */
+function makeTransactionCredential(opts: {
+  txXdr: string
+  amount: string
+  currency: string
+  recipient: string
+}) {
+  const challenge = Challenge.from({
+    id: `test-${crypto.randomUUID()}`,
+    realm: 'localhost',
+    method: 'stellar',
+    intent: 'charge',
+    request: {
+      amount: opts.txXdr ? opts.amount : '0',
+      currency: opts.currency,
+      recipient: opts.recipient,
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'testnet',
+      },
+    },
+  })
+  return Credential.from({
+    challenge,
+    payload: {
+      type: 'transaction',
+      xdr: opts.txXdr,
+    },
+  })
+}
 
 describe('stellar server charge', () => {
   it('creates a server method with correct name and intent', () => {
@@ -76,5 +233,287 @@ describe('stellar server charge', () => {
       decimals: 6,
     })
     expect(method.name).toBe('stellar')
+  })
+})
+
+describe('stellar server charge verification', () => {
+  const TEST_CONTRACT = makeContractId(1)
+  const SENDER = Keypair.random()
+
+  it('signature path: verifies matching SAC transfer in envelope', async () => {
+    const tx = buildSacTransferTx({
+      sender: SENDER,
+      recipientPubkey: RECIPIENT,
+      contractId: TEST_CONTRACT,
+      amount: 1000000n,
+    })
+
+    mockGetTransaction.mockResolvedValueOnce(mockTxResult(tx))
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeSignatureCredential({
+      hash: 'abc123hash',
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    const receipt = await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.reference).toBe('abc123hash')
+  })
+
+  it('signature path: throws when envelope is missing', async () => {
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      // no envelopeXdr
+    })
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeSignatureCredential({
+      hash: 'missing-env-hash',
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Transaction envelope is missing')
+  })
+
+  it('signature path: throws when tx is not successful', async () => {
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'FAILED',
+    })
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeSignatureCredential({
+      hash: 'failed-tx-hash',
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('is not successful')
+  })
+
+  it('signature path: rejects wrong recipient', async () => {
+    const wrongRecipient = Keypair.random().publicKey()
+    const tx = buildSacTransferTx({
+      sender: SENDER,
+      recipientPubkey: wrongRecipient,
+      contractId: TEST_CONTRACT,
+      amount: 1000000n,
+    })
+
+    mockGetTransaction.mockResolvedValueOnce(mockTxResult(tx))
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeSignatureCredential({
+      hash: 'wrong-recipient-hash',
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('does not contain a matching SAC transfer')
+  })
+
+  it('signature path: rejects wrong amount', async () => {
+    const tx = buildSacTransferTx({
+      sender: SENDER,
+      recipientPubkey: RECIPIENT,
+      contractId: TEST_CONTRACT,
+      amount: 500000n, // wrong — expects 1000000
+    })
+
+    mockGetTransaction.mockResolvedValueOnce(mockTxResult(tx))
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeSignatureCredential({
+      hash: 'wrong-amount-hash',
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('does not contain a matching SAC transfer')
+  })
+
+  it('signature path: rejects wrong contract', async () => {
+    const wrongContract = makeContractId(2)
+    const tx = buildSacTransferTx({
+      sender: SENDER,
+      recipientPubkey: RECIPIENT,
+      contractId: wrongContract,
+      amount: 1000000n,
+    })
+
+    mockGetTransaction.mockResolvedValueOnce(mockTxResult(tx))
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeSignatureCredential({
+      hash: 'wrong-contract-hash',
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('does not contain a matching SAC transfer')
+  })
+
+  it('transaction path: verifies and submits matching SAC transfer', async () => {
+    const tx = buildSacTransferTx({
+      sender: SENDER,
+      recipientPubkey: RECIPIENT,
+      contractId: TEST_CONTRACT,
+      amount: 1000000n,
+    })
+
+    const fakeHash = 'submitted-tx-hash-123'
+    mockSendTransaction.mockResolvedValueOnce({ hash: fakeHash })
+    mockGetTransaction.mockResolvedValueOnce({ status: 'SUCCESS' })
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeTransactionCredential({
+      txXdr: tx.toXDR(),
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    const receipt = await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.reference).toBe(fakeHash)
+  })
+
+  it('transaction path: rejects tx without invokeHostFunction', async () => {
+    // Build a tx with no operations (stub) — no invokeHostFunction
+    const sender = Keypair.random()
+    const account = new Account(sender.publicKey(), '0')
+    const stubTx = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: Networks.TESTNET,
+    })
+      .setTimeout(30)
+      .build()
+
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+    })
+
+    const credential = makeTransactionCredential({
+      txXdr: stubTx.toXDR(),
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('does not contain a Soroban invocation')
+  })
+
+  it('replay protection: rejects reused challenge', async () => {
+    const tx = buildSacTransferTx({
+      sender: SENDER,
+      recipientPubkey: RECIPIENT,
+      contractId: TEST_CONTRACT,
+      amount: 1000000n,
+    })
+
+    mockGetTransaction.mockResolvedValue(mockTxResult(tx))
+
+    const store = Store.memory()
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: TEST_CONTRACT,
+      store,
+    })
+
+    const credential = makeSignatureCredential({
+      hash: 'replay-test-hash',
+      amount: '1000000',
+      currency: TEST_CONTRACT,
+      recipient: RECIPIENT,
+    })
+
+    // First call succeeds
+    await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+
+    // Second call with same challenge ID should be rejected
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Replay rejected')
   })
 })

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -152,7 +152,14 @@ export function charge(parameters: charge.Parameters) {
           const sendResult = await server.sendTransaction(txToSubmit)
 
           let txResult = await server.getTransaction(sendResult.hash)
+          let txAttempts = 0
           while (txResult.status === 'NOT_FOUND') {
+            if (++txAttempts >= 60) {
+              throw new PaymentVerificationError(
+                `Transaction not found after ${txAttempts} attempts.`,
+                { hash: sendResult.hash },
+              )
+            }
             await new Promise((r) => setTimeout(r, 1000))
             txResult = await server.getTransaction(sendResult.hash)
           }
@@ -261,32 +268,37 @@ function verifySacTransfer(
   txResult: rpc.Api.GetSuccessfulTransactionResponse,
   expected: { amount: bigint; currency: string; recipient: string },
 ) {
-  if (txResult.envelopeXdr) {
-    const envelope =
-      typeof txResult.envelopeXdr === 'string'
-        ? xdr.TransactionEnvelope.fromXDR(txResult.envelopeXdr, 'base64')
-        : txResult.envelopeXdr
+  if (!txResult.envelopeXdr) {
+    throw new PaymentVerificationError(
+      'Transaction envelope is missing — cannot verify SAC transfer.',
+      {},
+    )
+  }
 
+  const envelope =
+    typeof txResult.envelopeXdr === 'string'
+      ? xdr.TransactionEnvelope.fromXDR(txResult.envelopeXdr, 'base64')
+      : txResult.envelopeXdr
+
+  // Determine network passphrase — try testnet first, then mainnet
+  let innerTx: Transaction | null = null
+  for (const np of [NETWORK_PASSPHRASE.testnet, NETWORK_PASSPHRASE.public]) {
     try {
-      // Determine network passphrase — try testnet first, then mainnet
-      let innerTx: Transaction | null = null
-      for (const np of [NETWORK_PASSPHRASE.testnet, NETWORK_PASSPHRASE.public]) {
-        try {
-          innerTx = new Transaction(envelope, np)
-          break
-        } catch {
-          continue
-        }
-      }
-
-      if (innerTx) {
-        verifyFromRawOps(innerTx, expected)
-        return
-      }
+      innerTx = new Transaction(envelope, np)
+      break
     } catch {
-      // Fall through — cannot verify envelope
+      continue
     }
   }
+
+  if (!innerTx) {
+    throw new PaymentVerificationError(
+      'Could not parse transaction envelope — cannot verify SAC transfer.',
+      {},
+    )
+  }
+
+  verifyFromRawOps(innerTx, expected)
 }
 
 function scValToBigInt(val: xdr.ScVal): bigint {


### PR DESCRIPTION
## Summary

Addresses remaining Copilot review comments from PR #1 that were still present in the merged code.

## Security fix

**`verifySacTransfer` now fails closed** — Previously, if `envelopeXdr` was missing from the RPC response or the envelope couldn't be parsed, the function silently returned without throwing, allowing the `signature` verification path to issue a success receipt without confirming the SAC transfer actually matched. Now it throws a `PaymentVerificationError` in both cases.

## Bug fix

**Transaction polling timeout** — The `transaction` verification path polled `getTransaction()` indefinitely with no max attempts. Added a 60-attempt limit (same pattern as channel `withdraw()`).

## Improvement

**`lsof` guard in demo/run.sh** — Added `command -v lsof` check before using `lsof` to free ports, so the script doesn't error on systems without it.

## Tests

Added 9 new verification tests for the charge server with mocked RPC (`getTransaction`, `sendTransaction`), covering:

- Signature path: valid SAC transfer verification, missing envelope, failed tx, wrong recipient, wrong amount, wrong contract
- Transaction path: valid submit-and-verify, missing invokeHostFunction rejection
- Replay protection with Store

57 tests across 5 files, all passing.
