### PR TITLE
docs: add Mermaid architecture and flow diagrams

### DIFF
--- a/diagrams/channel-flow.md
+++ b/diagrams/channel-flow.md
@@ -1,0 +1,52 @@
+# Channel Payment Flow — Off-Chain Commitments + On-Chain Close
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant CC as channel/client/Channel.ts<br/>channel()
+    participant RPC as Soroban RPC
+    participant SC as channel/server/Channel.ts<br/>channel()
+    participant Store as Store<br/>(cumulative tracker)
+    participant Contract as Channel Contract<br/>(on-chain)
+
+    Note over App,Contract: === Off-Chain Payment (repeatable N times) ===
+
+    App->>SC: HTTP request to paid endpoint
+    SC->>Store: Get cumulative amount<br/>key: stellar:channel:cumulative:{addr}
+    Store-->>SC: previousCumulative (or 0)
+    SC->>SC: request(): toBaseUnits(amount)<br/>generate UUID reference<br/>inject cumulativeAmount
+    SC-->>App: 402 + Challenge JSON<br/>{amount, channel, methodDetails:{cumulativeAmount}}
+
+    App->>CC: createCredential(challenge)
+    CC->>CC: newCumulative = previousCumulative + amount
+    CC->>RPC: simulate prepare_commitment(newCumulative)
+    RPC-->>CC: commitment bytes (32 bytes)
+    CC->>CC: ed25519.sign(commitmentBytes, commitmentKey)
+    CC->>CC: Convert signature → 128 hex chars
+    CC-->>App: Credential {amount: cumulative, signature: hex}
+
+    App->>SC: Credential
+    SC->>SC: Validate hex (128 chars, valid hex)
+    SC->>Store: Get previousCumulative
+    SC->>SC: Verify monotonicity:<br/>commitmentAmount ≥ prev + requested
+    SC->>RPC: simulate prepare_commitment(commitmentAmount)
+    RPC-->>SC: commitment bytes
+    SC->>SC: commitmentKey.verify(signature, commitmentBytes)
+    SC->>Store: Save new cumulative amount
+    SC-->>App: Receipt {status:'success'}
+
+    Note over App,Contract: === On-Chain Settlement (once, when done) ===
+
+    rect rgb(255, 240, 230)
+        App->>SC: close(channel, amount, signature, closeKey)
+        SC->>RPC: Build close(amount, signature) invocation
+        SC->>RPC: simulateTransaction
+        RPC-->>SC: Prepared TX
+        SC->>SC: closeKey.sign(tx)
+        SC->>RPC: sendTransaction
+        RPC->>Contract: close(amount, signature)
+        Contract->>Contract: Verify sig, transfer funds
+        RPC-->>SC: TX confirmed
+        SC-->>App: txHash
+    end
+```

--- a/diagrams/channel-flow.md
+++ b/diagrams/channel-flow.md
@@ -40,7 +40,7 @@ sequenceDiagram
     rect rgb(255, 240, 230)
         App->>SC: close(channel, amount, signature, closeKey)
         SC->>RPC: Build close(amount, signature) invocation
-        SC->>RPC: simulateTransaction
+        SC->>RPC: prepareTransaction
         RPC-->>SC: Prepared TX
         SC->>SC: closeKey.sign(tx)
         SC->>RPC: sendTransaction

--- a/diagrams/charge-flow.md
+++ b/diagrams/charge-flow.md
@@ -17,7 +17,7 @@ sequenceDiagram
 
     App->>CC: createCredential(challenge)
     CC->>CC: Resolve network, build SAC transfer(from, to, amount)
-    CC->>RPC: simulateTransaction(transferOp)
+    CC->>RPC: prepareTransaction(transferOp)
     RPC-->>CC: Prepared TX with resources
 
     CC->>CC: keypair.sign(preparedTx)
@@ -33,7 +33,6 @@ sequenceDiagram
         RPC->>Chain: Broadcast
         SC->>RPC: Poll getTransaction(hash)
         RPC-->>SC: TX confirmed
-        SC->>SC: verifySacTransfer(result) — verify on-chain
         SC-->>App: Receipt {status:'success', reference:txHash}
     else Push Mode
         CC->>RPC: sendTransaction(signedTx)

--- a/diagrams/charge-flow.md
+++ b/diagrams/charge-flow.md
@@ -1,0 +1,50 @@
+# Charge Payment Flow — On-Chain SAC Transfer
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant CC as client/Charge.ts<br/>charge()
+    participant RPC as Soroban RPC
+    participant SC as server/Charge.ts<br/>charge()
+    participant Chain as Stellar Network
+
+    Note over App,Chain: === 402 Challenge/Credential Flow (mppx) ===
+
+    App->>SC: HTTP request to paid endpoint
+    SC->>SC: defaults(): inject currency, recipient
+    SC->>SC: request(): toBaseUnits(amount)<br/>generate UUID reference<br/>inject methodDetails
+    SC-->>App: 402 + Challenge JSON<br/>{amount, currency, recipient, methodDetails}
+
+    App->>CC: createCredential(challenge)
+    CC->>CC: Resolve network, build SAC transfer(from, to, amount)
+    CC->>RPC: simulateTransaction(transferOp)
+    RPC-->>CC: Prepared TX with resources
+
+    CC->>CC: keypair.sign(preparedTx)
+
+    alt Pull Mode (default)
+        CC-->>App: Credential {type:'transaction', xdr}
+        App->>SC: Credential with signed XDR
+        SC->>SC: verifySacInvocation(tx) — validate structure
+        opt feePayer configured
+            SC->>SC: Wrap in fee-bump transaction
+        end
+        SC->>RPC: sendTransaction(signedTx)
+        RPC->>Chain: Broadcast
+        SC->>RPC: Poll getTransaction(hash)
+        RPC-->>SC: TX confirmed
+        SC->>SC: verifySacTransfer(result) — verify on-chain
+        SC-->>App: Receipt {status:'success', reference:txHash}
+    else Push Mode
+        CC->>RPC: sendTransaction(signedTx)
+        RPC->>Chain: Broadcast
+        CC->>RPC: Poll getTransaction(hash)
+        RPC-->>CC: TX confirmed
+        CC-->>App: Credential {type:'signature', hash}
+        App->>SC: Credential with tx hash
+        SC->>RPC: getTransaction(hash)
+        RPC-->>SC: TX result
+        SC->>SC: verifySacTransfer(result) — verify on-chain
+        SC-->>App: Receipt {status:'success', reference:hash}
+    end
+```

--- a/diagrams/mindmap.md
+++ b/diagrams/mindmap.md
@@ -1,0 +1,82 @@
+# Stellar MPP SDK — Mindmap
+
+```mermaid
+mindmap
+  root((Stellar MPP SDK))
+    Schemas
+      Methods.ts — Charge
+        name: stellar
+        intent: charge
+        Credential: signature | transaction
+        Request: amount, currency, recipient
+      channel/Methods.ts — Channel
+        name: stellar
+        intent: channel
+        Credential: amount + signature
+        Request: amount, channel address
+      Zod validation
+        zod/mini schemas
+        Discriminated unions
+    Constants
+      NETWORK_PASSPHRASE
+      SOROBAN_RPC_URLS
+      HORIZON_URLS
+      SAC_ADDRESSES — USDC & XLM
+      DEFAULT_DECIMALS: 7
+    Client
+      Charge — client/Charge.ts
+        Pull mode: sign XDR, server broadcasts
+        Push mode: client broadcasts, send hash
+        TransactionBuilder + simulateTransaction
+        keypair.sign
+        Progress events
+      Channel — channel/client/Channel.ts
+        simulate prepare_commitment
+        ed25519.sign commitment bytes
+        Cumulative amount tracking
+        No on-chain tx needed
+    Server
+      Charge — server/Charge.ts
+        defaults hook: currency + recipient
+        request hook: toBaseUnits, UUID, methodDetails
+        verify hook
+          Pull: verifySacInvocation → broadcast → poll
+          Push: fetch tx → verifySacTransfer
+          Fee-bump wrapping
+          Replay protection via Store
+      Channel — channel/server/Channel.ts
+        request hook: cumulative from Store
+        verify hook
+          Hex validation 128 chars
+          Monotonicity check
+          prepare_commitment simulation
+          Ed25519 signature verification
+          Store update
+        close function
+          On-chain settlement
+          Calls contract close method
+          Signs + broadcasts tx
+    mppx Framework
+      Method.from — define schema
+      Method.toClient — wrap client
+      Method.toServer — wrap server
+      Challenge — 402 payment required
+      Credential — signed proof
+      Receipt — payment confirmation
+      Store — replay protection
+    External
+      @stellar/stellar-sdk
+        Keypair
+        Contract
+        rpc.Server
+        TransactionBuilder
+      Soroban RPC
+        simulateTransaction
+        sendTransaction
+        getTransaction
+      One-Way Channel Contract
+        prepare_commitment
+        close
+        top_up
+        refund
+```

--- a/diagrams/mindmap.md
+++ b/diagrams/mindmap.md
@@ -27,7 +27,7 @@ mindmap
       Charge — client/Charge.ts
         Pull mode: sign XDR, server broadcasts
         Push mode: client broadcasts, send hash
-        TransactionBuilder + simulateTransaction
+        TransactionBuilder + rpc.Server.prepareTransaction
         keypair.sign
         Progress events
       Channel — channel/client/Channel.ts

--- a/diagrams/module-architecture.md
+++ b/diagrams/module-architecture.md
@@ -9,7 +9,7 @@ graph TB
     subgraph "Schemas & Constants"
         METHODS["Methods.ts<br/><i>charge schema</i><br/>Method.from name:stellar intent:charge"]
         CH_METHODS["channel/Methods.ts<br/><i>channel schema</i><br/>Method.from name:stellar intent:channel"]
-        CONST["constants.ts<br/>NETWORK_PASSPHRASE<br/>SOROBAN_RPC_URLS<br/>SAC_ADDRESSES<br/>DECIMALS / FEE / TIMEOUT"]
+        CONST["constants.ts<br/>NETWORK_PASSPHRASE<br/>SOROBAN_RPC_URLS<br/>SAC_ADDRESSES<br/>HORIZON_URLS<br/>DEFAULT_DECIMALS / DEFAULT_FEE / DEFAULT_TIMEOUT"]
     end
 
     subgraph "Client Side"
@@ -24,8 +24,8 @@ graph TB
         direction TB
         S_CHARGE["server/Charge.ts<br/><b>charge()</b><br/>Method.toServer(charge, {request,verify})"]
         S_CHANNEL["channel/server/Channel.ts<br/><b>channel()</b> + <b>close()</b><br/>Method.toServer(channel, {request,verify})"]
-        S_IDX["server/index.ts<br/>exports: charge, stellar, Store, Expires"]
-        S_CH_IDX["channel/server/index.ts<br/>exports: channel, close, stellar, Store"]
+        S_IDX["server/index.ts<br/>exports: charge, stellar, Store, Expires, Mppx"]
+        S_CH_IDX["channel/server/index.ts<br/>exports: channel, close, stellar, Store, Expires, Mppx"]
     end
 
     subgraph "External Dependencies"

--- a/diagrams/module-architecture.md
+++ b/diagrams/module-architecture.md
@@ -1,0 +1,61 @@
+# Stellar MPP SDK — Module Architecture
+
+```mermaid
+graph TB
+    subgraph "Root Exports (sdk/src/index.ts)"
+        IDX["index.ts"]
+    end
+
+    subgraph "Schemas & Constants"
+        METHODS["Methods.ts<br/><i>charge schema</i><br/>Method.from name:stellar intent:charge"]
+        CH_METHODS["channel/Methods.ts<br/><i>channel schema</i><br/>Method.from name:stellar intent:channel"]
+        CONST["constants.ts<br/>NETWORK_PASSPHRASE<br/>SOROBAN_RPC_URLS<br/>SAC_ADDRESSES<br/>DECIMALS / FEE / TIMEOUT"]
+    end
+
+    subgraph "Client Side"
+        direction TB
+        C_CHARGE["client/Charge.ts<br/><b>charge()</b><br/>Method.toClient(charge, createCredential)"]
+        C_CHANNEL["channel/client/Channel.ts<br/><b>channel()</b><br/>Method.toClient(channel, createCredential)"]
+        C_IDX["client/index.ts<br/>exports: charge, stellar, Mppx"]
+        C_CH_IDX["channel/client/index.ts<br/>exports: channel, stellar, Mppx"]
+    end
+
+    subgraph "Server Side"
+        direction TB
+        S_CHARGE["server/Charge.ts<br/><b>charge()</b><br/>Method.toServer(charge, {request,verify})"]
+        S_CHANNEL["channel/server/Channel.ts<br/><b>channel()</b> + <b>close()</b><br/>Method.toServer(channel, {request,verify})"]
+        S_IDX["server/index.ts<br/>exports: charge, stellar, Store, Expires"]
+        S_CH_IDX["channel/server/index.ts<br/>exports: channel, close, stellar, Store"]
+    end
+
+    subgraph "External Dependencies"
+        MPPX["mppx<br/>Method · Challenge · Credential · Receipt · Store"]
+        STELLAR["@stellar/stellar-sdk<br/>Keypair · Contract · rpc.Server<br/>TransactionBuilder · Address"]
+        ZOD["zod/mini<br/>Schema Validation"]
+    end
+
+    IDX --> METHODS
+    IDX --> CH_METHODS
+    IDX --> CONST
+
+    METHODS --> C_CHARGE
+    METHODS --> S_CHARGE
+    CH_METHODS --> C_CHANNEL
+    CH_METHODS --> S_CHANNEL
+
+    CONST --> C_CHARGE
+    CONST --> S_CHARGE
+    CONST --> C_CHANNEL
+    CONST --> S_CHANNEL
+
+    C_CHARGE --> MPPX
+    C_CHARGE --> STELLAR
+    C_CHANNEL --> MPPX
+    C_CHANNEL --> STELLAR
+    S_CHARGE --> MPPX
+    S_CHARGE --> STELLAR
+    S_CHANNEL --> MPPX
+    S_CHANNEL --> STELLAR
+    METHODS --> ZOD
+    CH_METHODS --> ZOD
+```


### PR DESCRIPTION
Adds four Mermaid diagram files under `diagrams/`:

- **module-architecture.md** — module dependency graph showing SDK structure
- **mindmap.md** — high-level concept map of the SDK
- **charge-flow.md** — sequence diagram for on-chain SAC transfer (Charge flow)
- **channel-flow.md** — sequence diagram for off-chain commitments + on-chain close (Channel flow)

These render natively in GitHub Markdown.