### PR TITLE
fix: address bugs found in codebase review

### DIFF
--- a/sdk/src/Methods.ts
+++ b/sdk/src/Methods.ts
@@ -71,6 +71,7 @@ export const charge = Method.from({
  */
 export function toBaseUnits(amount: string, decimals: number): string {
   const [whole = '0', frac = ''] = amount.split('.')
+  if (decimals === 0) return BigInt(whole).toString()
   const paddedFrac = frac.padEnd(decimals, '0').slice(0, decimals)
   return (BigInt(whole) * 10n ** BigInt(decimals) + BigInt(paddedFrac)).toString()
 }

--- a/sdk/src/Methods.ts
+++ b/sdk/src/Methods.ts
@@ -72,7 +72,7 @@ export const charge = Method.from({
 export function toBaseUnits(amount: string, decimals: number): string {
   const [whole = '0', frac = ''] = amount.split('.')
   const paddedFrac = frac.padEnd(decimals, '0').slice(0, decimals)
-  return (BigInt(whole) * BigInt(10 ** decimals) + BigInt(paddedFrac)).toString()
+  return (BigInt(whole) * 10n ** BigInt(decimals) + BigInt(paddedFrac)).toString()
 }
 
 /**
@@ -85,7 +85,7 @@ export function toBaseUnits(amount: string, decimals: number): string {
  */
 export function fromBaseUnits(baseUnits: string, decimals: number): string {
   const bi = BigInt(baseUnits)
-  const divisor = BigInt(10 ** decimals)
+  const divisor = 10n ** BigInt(decimals)
   const whole = (bi / divisor).toString()
   const remainder = (bi % divisor).toString().padStart(decimals, '0')
   return `${whole}.${remainder}`

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -223,9 +223,6 @@ export function channel(parameters: channel.Parameters) {
         })
       }
 
-      // Calculate the incremental payment
-      const incrementalAmount = commitmentAmount - previousCumulative
-
       return Receipt.from({
         method: 'stellar',
         reference: challengeRequest.methodDetails?.reference ?? challenge.id,

--- a/sdk/src/client/Charge.ts
+++ b/sdk/src/client/Charge.ts
@@ -53,6 +53,12 @@ export function charge(parameters: charge.Parameters) {
     timeout = DEFAULT_TIMEOUT,
   } = parameters
 
+  if (!keypairParam && !secretKey) {
+    throw new Error(
+      'Either keypair or secretKey must be provided.',
+    )
+  }
+
   const keypair = keypairParam ?? Keypair.fromSecret(secretKey!)
 
   return Method.toClient(Methods.charge, {
@@ -125,7 +131,13 @@ export function charge(parameters: charge.Parameters) {
         // Poll until confirmed
         onProgress?.({ type: 'confirming', hash: result.hash })
         let txResult = await server.getTransaction(result.hash)
+        let pollAttempts = 0
         while (txResult.status === 'NOT_FOUND') {
+          if (++pollAttempts >= 60) {
+            throw new Error(
+              `Transaction not confirmed after ${pollAttempts} attempts.`,
+            )
+          }
           await new Promise((r) => setTimeout(r, 1000))
           txResult = await server.getTransaction(result.hash)
         }

--- a/sdk/src/client/Charge.ts
+++ b/sdk/src/client/Charge.ts
@@ -135,7 +135,7 @@ export function charge(parameters: charge.Parameters) {
         while (txResult.status === 'NOT_FOUND') {
           if (++pollAttempts >= 60) {
             throw new Error(
-              `Transaction not confirmed after ${pollAttempts} attempts.`,
+              `Transaction not confirmed after ${pollAttempts} polling attempts.`,
             )
           }
           await new Promise((r) => setTimeout(r, 1000))

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -152,7 +152,14 @@ export function charge(parameters: charge.Parameters) {
           const sendResult = await server.sendTransaction(txToSubmit)
 
           let txResult = await server.getTransaction(sendResult.hash)
+          let txAttempts = 0
           while (txResult.status === 'NOT_FOUND') {
+            if (++txAttempts >= 60) {
+              throw new PaymentVerificationError(
+                `Transaction not found after ${txAttempts} attempts.`,
+                { hash: sendResult.hash },
+              )
+            }
             await new Promise((r) => setTimeout(r, 1000))
             txResult = await server.getTransaction(sendResult.hash)
           }
@@ -261,32 +268,37 @@ function verifySacTransfer(
   txResult: rpc.Api.GetSuccessfulTransactionResponse,
   expected: { amount: bigint; currency: string; recipient: string },
 ) {
-  if (txResult.envelopeXdr) {
-    const envelope =
-      typeof txResult.envelopeXdr === 'string'
-        ? xdr.TransactionEnvelope.fromXDR(txResult.envelopeXdr, 'base64')
-        : txResult.envelopeXdr
+  if (!txResult.envelopeXdr) {
+    throw new PaymentVerificationError(
+      'Transaction result is missing envelope XDR — cannot verify payment.',
+      {},
+    )
+  }
 
+  const envelope =
+    typeof txResult.envelopeXdr === 'string'
+      ? xdr.TransactionEnvelope.fromXDR(txResult.envelopeXdr, 'base64')
+      : txResult.envelopeXdr
+
+  // Determine network passphrase — try testnet first, then mainnet
+  let innerTx: Transaction | null = null
+  for (const np of [NETWORK_PASSPHRASE.testnet, NETWORK_PASSPHRASE.public]) {
     try {
-      // Determine network passphrase — try testnet first, then mainnet
-      let innerTx: Transaction | null = null
-      for (const np of [NETWORK_PASSPHRASE.testnet, NETWORK_PASSPHRASE.public]) {
-        try {
-          innerTx = new Transaction(envelope, np)
-          break
-        } catch {
-          continue
-        }
-      }
-
-      if (innerTx) {
-        verifyFromRawOps(innerTx, expected)
-        return
-      }
+      innerTx = new Transaction(envelope, np)
+      break
     } catch {
-      // Fall through — cannot verify envelope
+      continue
     }
   }
+
+  if (!innerTx) {
+    throw new PaymentVerificationError(
+      'Could not parse transaction envelope for verification.',
+      {},
+    )
+  }
+
+  verifyFromRawOps(innerTx, expected)
 }
 
 function scValToBigInt(val: xdr.ScVal): bigint {
@@ -311,14 +323,14 @@ function scValToBigInt(val: xdr.ScVal): bigint {
   if (switchValue === xdr.ScValType.scvU128().value) {
     const parts = val.u128()
     const hi = BigInt(parts.hi().toString())
-    const lo = BigInt(parts.lo().toString())
+    const lo = BigInt(parts.lo().toString()) & 0xFFFFFFFFFFFFFFFFn
     return (hi << 64n) | lo
   }
   // scvI128 = 10
   if (switchValue === xdr.ScValType.scvI128().value) {
     const parts = val.i128()
     const hi = BigInt(parts.hi().toString())
-    const lo = BigInt(parts.lo().toString())
+    const lo = BigInt(parts.lo().toString()) & 0xFFFFFFFFFFFFFFFFn
     return (hi << 64n) | lo
   }
   throw new Error(`Cannot convert ScVal type ${switchValue} to BigInt`)

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -156,7 +156,7 @@ export function charge(parameters: charge.Parameters) {
           while (txResult.status === 'NOT_FOUND') {
             if (++txAttempts >= 60) {
               throw new PaymentVerificationError(
-                `Transaction not found after ${txAttempts} attempts.`,
+                `Transaction not found after ${txAttempts} polling attempts.`,
                 { hash: sendResult.hash },
               )
             }
@@ -275,10 +275,25 @@ function verifySacTransfer(
     )
   }
 
-  const envelope =
-    typeof txResult.envelopeXdr === 'string'
-      ? xdr.TransactionEnvelope.fromXDR(txResult.envelopeXdr, 'base64')
-      : txResult.envelopeXdr
+  let envelope: xdr.TransactionEnvelope
+  if (typeof txResult.envelopeXdr === 'string') {
+    try {
+      envelope = xdr.TransactionEnvelope.fromXDR(
+        txResult.envelopeXdr,
+        'base64',
+      )
+    } catch (error) {
+      throw new PaymentVerificationError(
+        'Could not parse transaction envelope for verification.',
+        {
+          details:
+            error instanceof Error ? error.message : String(error),
+        },
+      )
+    }
+  } else {
+    envelope = txResult.envelopeXdr
+  }
 
   // Determine network passphrase — try testnet first, then mainnet
   let innerTx: Transaction | null = null


### PR DESCRIPTION
Fixes 7 bugs identified in a codebase review, ordered by severity.

## Changes

### Security (CRITICAL)
- **`verifySacTransfer` now fails closed** — Previously, if `envelopeXdr` was missing or the transaction envelope couldn't be parsed, the function returned silently, allowing unverified payments to receive success receipts. Now throws `PaymentVerificationError` in both cases.

### Bug Fixes (HIGH)
- **Server-side tx polling capped at 60 attempts** — The `transaction` verification path in `server/Charge.ts` polled `getTransaction` indefinitely. Added a 60-attempt limit matching the `close()` function pattern.
- **Client-side push polling capped at 60 attempts** — The push-mode polling loop in `client/Charge.ts` had the same infinite loop risk. Now capped at 60 attempts.

### Bug Fixes (MEDIUM)  
- **`scValToBigInt` i128/u128 fix** — The `lo` component of 128-bit values is an unsigned 64-bit integer. Added `& 0xFFFFFFFFFFFFFFFFn` bitmask to ensure correct reconstruction when bitwise-ORing with the shifted `hi` part.
- **Removed unused `incrementalAmount`** — Dead variable in `channel/server/Channel.ts` that was computed but never used.

### Robustness (LOW)
- **BigInt exponentiation in `toBaseUnits`/`fromBaseUnits`** — Replaced `BigInt(10 ** decimals)` (Number arithmetic, loses precision above ~15 digits) with `10n ** BigInt(decimals)` (pure BigInt, arbitrary precision).
- **Early keypair validation in client charge** — Added guard that either `keypair` or `secretKey` must be provided, matching the channel client's existing validation pattern.

## Testing
All 88 tests pass, TypeScript build clean.
