### PR TITLE
feat: action-discriminated credentials, on-chain state utilities, and event watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.tsbuildinfo
 .DS_Store
 .claude/
+package-lock.json

--- a/sdk/src/channel/Methods.test.ts
+++ b/sdk/src/channel/Methods.test.ts
@@ -55,19 +55,33 @@ describe('channel method schema', () => {
     expect(result.methodDetails).toBeUndefined()
   })
 
-  it('credential payload accepts amount and signature', () => {
+  it('credential payload accepts voucher action with amount and signature', () => {
     const validSig = 'a'.repeat(128)
     const result = channel.schema.credential.payload.parse({
+      action: 'voucher',
       amount: '3000000',
       signature: validSig,
     })
+    expect(result.action).toBe('voucher')
     expect(result.amount).toBe('3000000')
     expect(result.signature).toBe(validSig)
+  })
+
+  it('credential payload accepts close action', () => {
+    const validSig = 'a'.repeat(128)
+    const result = channel.schema.credential.payload.parse({
+      action: 'close',
+      amount: '5000000',
+      signature: validSig,
+    })
+    expect(result.action).toBe('close')
+    expect(result.amount).toBe('5000000')
   })
 
   it('credential payload rejects non-numeric amount', () => {
     expect(() =>
       channel.schema.credential.payload.parse({
+        action: 'voucher',
         amount: 'abc',
         signature: 'a'.repeat(128),
       }),
@@ -77,6 +91,7 @@ describe('channel method schema', () => {
   it('credential payload rejects invalid hex signature', () => {
     expect(() =>
       channel.schema.credential.payload.parse({
+        action: 'voucher',
         amount: '1000000',
         signature: 'not-hex',
       }),
@@ -86,8 +101,19 @@ describe('channel method schema', () => {
   it('credential payload rejects wrong-length signature', () => {
     expect(() =>
       channel.schema.credential.payload.parse({
+        action: 'voucher',
         amount: '1000000',
         signature: 'abcdef',
+      }),
+    ).toThrow()
+  })
+
+  it('credential payload rejects unknown action', () => {
+    expect(() =>
+      channel.schema.credential.payload.parse({
+        action: 'topUp',
+        amount: '1000000',
+        signature: 'a'.repeat(128),
       }),
     ).toThrow()
   })

--- a/sdk/src/channel/Methods.ts
+++ b/sdk/src/channel/Methods.ts
@@ -15,12 +15,24 @@ export const channel = Method.from({
   intent: 'channel',
   schema: {
     credential: {
-      payload: z.object({
-        /** Cumulative amount authorised by this commitment (base units). */
-        amount: z.string().check(z.regex(/^\d+$/)),
-        /** Ed25519 signature over the commitment bytes (128 hex chars). */
-        signature: z.string().check(z.regex(/^[0-9a-f]{128}$/i)),
-      }),
+      payload: z.union([
+        z.object({
+          /** Action discriminator — pay a voucher. */
+          action: z.literal('voucher'),
+          /** Cumulative amount authorised by this commitment (base units). */
+          amount: z.string().check(z.regex(/^\d+$/)),
+          /** Ed25519 signature over the commitment bytes (128 hex chars). */
+          signature: z.string().check(z.regex(/^[0-9a-f]{128}$/i)),
+        }),
+        z.object({
+          /** Action discriminator — close the channel. */
+          action: z.literal('close'),
+          /** Cumulative amount authorised by this commitment (base units). */
+          amount: z.string().check(z.regex(/^\d+$/)),
+          /** Ed25519 signature over the commitment bytes (128 hex chars). */
+          signature: z.string().check(z.regex(/^[0-9a-f]{128}$/i)),
+        }),
+      ]),
     },
     request: z.object({
       /** Incremental payment amount in base units (stroops). */

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -57,6 +57,8 @@ export function channel(parameters: channel.Parameters) {
     context: z.object({
       /** Override the cumulative amount to commit. */
       cumulativeAmount: z.optional(z.string()),
+      /** Credential action: 'voucher' (default) or 'close'. */
+      action: z.optional(z.enum(['voucher', 'close'])),
     }),
     async createCredential({ challenge, context }) {
       const { request } = challenge
@@ -66,6 +68,8 @@ export function channel(parameters: channel.Parameters) {
 
       // The server tells us the cumulative amount via methodDetails,
       // or the caller can override via context.
+      const action = context?.action ?? 'voucher'
+
       const previousCumulative = BigInt(
         request.methodDetails?.cumulativeAmount ?? '0',
       )
@@ -139,6 +143,7 @@ export function channel(parameters: channel.Parameters) {
       return Credential.serialize({
         challenge,
         payload: {
+          action,
           amount: cumulativeAmount.toString(),
           signature: sigHex,
         },

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -615,4 +615,25 @@ describe('stellar server channel dispute detection', () => {
     expect(receipt.status).toBe('success')
     expect(mockGetChannelState).not.toHaveBeenCalled()
   })
+
+  it('throws a configuration error when checkOnChainState is true but sourceAccount is missing', async () => {
+    const credential = makeCredential({
+      amount: '1000000',
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      checkOnChainState: true,
+      // sourceAccount intentionally omitted
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('checkOnChainState requires sourceAccount to be set')
+  })
 })

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 // Hoisted mock stubs — accessible inside the vi.mock factory
 const mockGetAccount = vi.fn()
 const mockSimulateTransaction = vi.fn()
+const mockGetChannelState = vi.fn()
 
 vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>()
@@ -19,6 +20,10 @@ vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
     },
   }
 })
+
+vi.mock('./State.js', () => ({
+  getChannelState: (...args: unknown[]) => mockGetChannelState(...args),
+}))
 
 // Re-import after mock is set up
 const { channel } = await import('./Channel.js')
@@ -39,6 +44,7 @@ const CHANNEL_ADDRESS = 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC52
  * Build a fake credential for testing verify().
  */
 function makeCredential(opts: {
+  action?: 'voucher' | 'close'
   amount: string
   challengeAmount?: string
   cumulativeAmount?: string
@@ -62,6 +68,7 @@ function makeCredential(opts: {
   return Credential.from({
     challenge,
     payload: {
+      action: opts.action ?? 'voucher',
       amount: opts.amount,
       signature: opts.signature ?? 'a'.repeat(128),
     },
@@ -70,6 +77,7 @@ function makeCredential(opts: {
 
 /** Build a credential with a real ed25519 signature over `commitmentBytes`. */
 function makeSignedCredential(opts: {
+  action?: 'voucher' | 'close'
   commitmentBytes: Buffer
   cumulativeAmount: bigint
   challengeAmount: string
@@ -95,6 +103,7 @@ function makeSignedCredential(opts: {
   return Credential.from({
     challenge,
     payload: {
+      action: opts.action ?? 'voucher',
       amount: opts.cumulativeAmount.toString(),
       signature: sigHex,
     },
@@ -180,6 +189,15 @@ describe('stellar server channel', () => {
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
       sourceAccount: Keypair.random().publicKey(),
+    })
+    expect(method.name).toBe('stellar')
+  })
+
+  it('accepts closeKey parameter', () => {
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY.publicKey(),
+      closeKey: Keypair.random(),
     })
     expect(method.name).toBe('stellar')
   })
@@ -391,5 +409,210 @@ describe('stellar server channel verification', () => {
         request: credential.challenge.request,
       }),
     ).rejects.toThrow('Replay rejected')
+  })
+
+  it('rejects close action when closeKey is not configured', async () => {
+    const commitmentBytes = Buffer.from('close-test-bytes')
+    mockSimulateTransaction.mockResolvedValueOnce(
+      successSimResult(commitmentBytes),
+    )
+
+    const credential = makeSignedCredential({
+      action: 'close',
+      commitmentBytes,
+      cumulativeAmount: 1000000n,
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Close action requires a closeKey')
+  })
+})
+
+describe('stellar server channel dispute detection', () => {
+  it('rejects voucher when channel is closed (effective ledger reached)', async () => {
+    mockGetChannelState.mockResolvedValueOnce({
+      balance: 1000000n,
+      refundWaitingPeriod: 1000,
+      token: 'CTOKEN...',
+      from: 'GFROM...',
+      to: 'GTO...',
+      closeEffectiveAtLedger: 5000,
+      currentLedger: 5500, // past effective → closed
+    })
+
+    const credential = makeCredential({
+      amount: '1000000',
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      checkOnChainState: true,
+      sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Channel is closed')
+  })
+
+  it('calls onDisputeDetected when close_start detected but not yet effective', async () => {
+    const disputeState = {
+      balance: 1000000n,
+      refundWaitingPeriod: 1000,
+      token: 'CTOKEN...',
+      from: 'GFROM...',
+      to: 'GTO...',
+      closeEffectiveAtLedger: 6000,
+      currentLedger: 5500, // before effective → still open, but dispute started
+    }
+    mockGetChannelState.mockResolvedValueOnce(disputeState)
+
+    const commitmentBytes = Buffer.from('dispute-test-bytes')
+    mockSimulateTransaction.mockResolvedValueOnce(
+      successSimResult(commitmentBytes),
+    )
+
+    const onDisputeDetected = vi.fn()
+
+    const credential = makeSignedCredential({
+      commitmentBytes,
+      cumulativeAmount: 1000000n,
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      checkOnChainState: true,
+      sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+      onDisputeDetected,
+    })
+
+    const receipt = await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+
+    // Verification should still succeed (channel not yet closed)
+    expect(receipt.status).toBe('success')
+    // But dispute callback should have been called
+    expect(onDisputeDetected).toHaveBeenCalledWith(disputeState)
+  })
+
+  it('continues normally when on-chain check fails (network error)', async () => {
+    mockGetChannelState.mockRejectedValueOnce(new Error('network timeout'))
+
+    const commitmentBytes = Buffer.from('network-error-test')
+    mockSimulateTransaction.mockResolvedValueOnce(
+      successSimResult(commitmentBytes),
+    )
+
+    const credential = makeSignedCredential({
+      commitmentBytes,
+      cumulativeAmount: 1000000n,
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      checkOnChainState: true,
+      sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+    })
+
+    // Should still succeed — on-chain check failure is non-fatal
+    const receipt = await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+    expect(receipt.status).toBe('success')
+  })
+
+  it('caches on-chain state in store', async () => {
+    mockGetChannelState.mockResolvedValueOnce({
+      balance: 5000000n,
+      refundWaitingPeriod: 1000,
+      token: 'CTOKEN...',
+      from: 'GFROM...',
+      to: 'GTO...',
+      closeEffectiveAtLedger: null,
+      currentLedger: 4000,
+    })
+
+    const commitmentBytes = Buffer.from('cache-test-bytes')
+    mockSimulateTransaction.mockResolvedValueOnce(
+      successSimResult(commitmentBytes),
+    )
+
+    const store = Store.memory()
+
+    const credential = makeSignedCredential({
+      commitmentBytes,
+      cumulativeAmount: 1000000n,
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      checkOnChainState: true,
+      sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+      store,
+    })
+
+    await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+
+    const cached = (await store.get(
+      `stellar:channel:state:${CHANNEL_ADDRESS}`,
+    )) as { balance: string; currentLedger: number }
+    expect(cached).not.toBeNull()
+    expect(cached.balance).toBe('5000000')
+    expect(cached.currentLedger).toBe(4000)
+  })
+
+  it('skips on-chain check when checkOnChainState is false', async () => {
+    mockGetChannelState.mockClear()
+
+    const commitmentBytes = Buffer.from('skip-check-bytes')
+    mockSimulateTransaction.mockResolvedValueOnce(
+      successSimResult(commitmentBytes),
+    )
+
+    const credential = makeSignedCredential({
+      commitmentBytes,
+      cumulativeAmount: 1000000n,
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      // checkOnChainState defaults to false
+    })
+
+    const receipt = await method.verify({
+      credential: credential as any,
+      request: credential.challenge.request,
+    })
+    expect(receipt.status).toBe('success')
+    expect(mockGetChannelState).not.toHaveBeenCalled()
   })
 })

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -125,7 +125,13 @@ export function channel(parameters: channel.Parameters) {
       // close_start has been called on-chain. This mirrors Tempo's
       // close_requested_at guard — each incoming voucher refreshes
       // our view of the channel without requiring a background poller.
-      if (checkOnChainState && sourceAccount) {
+      if (checkOnChainState) {
+        if (!sourceAccount) {
+          throw new Error(
+            'checkOnChainState requires sourceAccount to be set. ' +
+            'Provide a funded Stellar account address (G...) to use for on-chain simulations.',
+          )
+        }
         try {
           const state = await getChannelState({
             channel: channelAddress,
@@ -452,7 +458,8 @@ export declare namespace channel {
     /**
      * When true, each verify call lazily reads on-chain state to detect
      * if `close_start` has been called (dispute detection). Requires
-     * `sourceAccount` to be set. @default false
+     * `sourceAccount` to be set — a configuration error is thrown if
+     * `sourceAccount` is missing when this is enabled. @default false
      */
     checkOnChainState?: boolean
     /**

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -14,6 +14,7 @@ import {
 } from '../../constants.js'
 import { toBaseUnits } from '../../Methods.js'
 import { channel as ChannelMethod } from '../Methods.js'
+import { getChannelState, type ChannelState } from './State.js'
 
 /**
  * Creates a Stellar one-way-channel method for use on the **server**.
@@ -42,9 +43,12 @@ import { channel as ChannelMethod } from '../Methods.js'
 export function channel(parameters: channel.Parameters) {
   const {
     channel: channelAddress,
+    checkOnChainState = false,
+    closeKey: closeKeyParam,
     commitmentKey: commitmentKeyParam,
     decimals = DEFAULT_DECIMALS,
     network = 'testnet',
+    onDisputeDetected,
     rpcUrl,
     sourceAccount,
     store,
@@ -60,6 +64,15 @@ export function channel(parameters: channel.Parameters) {
       return Keypair.fromPublicKey(commitmentKeyParam)
     }
     return commitmentKeyParam
+  })()
+
+  // Parse the optional close signer key
+  const closeKeypair = (() => {
+    if (!closeKeyParam) return undefined
+    if (typeof closeKeyParam === 'string') {
+      return Keypair.fromSecret(closeKeyParam)
+    }
+    return closeKeyParam
   })()
 
   // Track cumulative amounts per channel in the store
@@ -107,6 +120,53 @@ export function channel(parameters: channel.Parameters) {
       const payload = credential.payload
       const commitmentAmount = BigInt(payload.amount)
       const signatureHex = payload.signature
+
+      // Lazy on-chain dispute detection: if enabled, check whether
+      // close_start has been called on-chain. This mirrors Tempo's
+      // close_requested_at guard — each incoming voucher refreshes
+      // our view of the channel without requiring a background poller.
+      if (checkOnChainState && sourceAccount) {
+        try {
+          const state = await getChannelState({
+            channel: channelAddress,
+            network,
+            rpcUrl,
+            sourceAccount,
+          })
+
+          // Cache the on-chain state for the caller
+          if (store) {
+            await store.put(
+              `stellar:channel:state:${channelAddress}`,
+              {
+                balance: state.balance.toString(),
+                closeEffectiveAtLedger: state.closeEffectiveAtLedger,
+                currentLedger: state.currentLedger,
+                queriedAt: new Date().toISOString(),
+              },
+            )
+          }
+
+          if (state.closeEffectiveAtLedger != null) {
+            onDisputeDetected?.(state)
+
+            if (state.currentLedger >= state.closeEffectiveAtLedger) {
+              throw new ChannelVerificationError(
+                'Channel is closed: close effective ledger has been reached.',
+                {
+                  closeEffectiveAtLedger: String(state.closeEffectiveAtLedger),
+                  currentLedger: String(state.currentLedger),
+                },
+              )
+            }
+          }
+        } catch (error) {
+          // Re-throw ChannelVerificationError (channel closed)
+          if (error instanceof ChannelVerificationError) throw error
+          // Silently continue if on-chain check fails (network issue).
+          // The verify logic below still protects against invalid credentials.
+        }
+      }
 
       // Validate hex signature format
       if (!/^[0-9a-f]+$/i.test(signatureHex) || signatureHex.length % 2 !== 0) {
@@ -223,6 +283,76 @@ export function channel(parameters: channel.Parameters) {
         })
       }
 
+      // Dispatch on action
+      const action = payload.action ?? 'voucher'
+
+      if (action === 'close') {
+        if (!closeKeypair) {
+          throw new ChannelVerificationError(
+            'Close action requires a closeKey to be configured.',
+            {},
+          )
+        }
+
+        // Submit the close transaction on-chain
+        const closeOp = contract.call(
+          'close',
+          nativeToScVal(commitmentAmount, { type: 'i128' }),
+          nativeToScVal(Buffer.from(signatureBytes), { type: 'bytes' }),
+        )
+
+        const closeAccount = await server.getAccount(closeKeypair.publicKey())
+        const closeTx = new TransactionBuilder(closeAccount, {
+          fee: '100',
+          networkPassphrase,
+        })
+          .addOperation(closeOp)
+          .setTimeout(180)
+          .build()
+
+        const prepared = await server.prepareTransaction(closeTx)
+        prepared.sign(closeKeypair)
+
+        const sendResult = await server.sendTransaction(prepared)
+
+        const MAX_POLL_ATTEMPTS = 60
+        let txResult = await server.getTransaction(sendResult.hash)
+        let attempts = 0
+        while (txResult.status === 'NOT_FOUND') {
+          if (++attempts >= MAX_POLL_ATTEMPTS) {
+            throw new ChannelVerificationError(
+              `Close transaction not found after ${MAX_POLL_ATTEMPTS} attempts.`,
+              { hash: sendResult.hash },
+            )
+          }
+          await new Promise((r) => setTimeout(r, 1000))
+          txResult = await server.getTransaction(sendResult.hash)
+        }
+
+        if (txResult.status !== 'SUCCESS') {
+          throw new ChannelVerificationError(
+            `Close transaction failed: ${txResult.status}`,
+            { hash: sendResult.hash, status: txResult.status },
+          )
+        }
+
+        // Mark channel as finalized in store
+        if (store) {
+          await store.put(`stellar:channel:finalized:${channelAddress}`, {
+            finalizedAt: new Date().toISOString(),
+            txHash: sendResult.hash,
+            amount: commitmentAmount.toString(),
+          })
+        }
+
+        return Receipt.from({
+          method: 'stellar',
+          reference: sendResult.hash,
+          status: 'success',
+          timestamp: new Date().toISOString(),
+        })
+      }
+
       return Receipt.from({
         method: 'stellar',
         reference: challengeRequest.methodDetails?.reference ?? challenge.id,
@@ -320,6 +450,18 @@ export declare namespace channel {
     /** On-chain channel contract address (C...). */
     channel: string
     /**
+     * When true, each verify call lazily reads on-chain state to detect
+     * if `close_start` has been called (dispute detection). Requires
+     * `sourceAccount` to be set. @default false
+     */
+    checkOnChainState?: boolean
+    /**
+     * Keypair for signing close transactions. Required when handling
+     * close credential actions. Accepts a Stellar secret key string (S...)
+     * or a Keypair instance.
+     */
+    closeKey?: string | Keypair
+    /**
      * Ed25519 public key for verifying commitment signatures.
      * Accepts a Stellar public key string (G...) or a Keypair instance.
      */
@@ -328,6 +470,11 @@ export declare namespace channel {
     decimals?: number
     /** Stellar network. @default 'testnet' */
     network?: NetworkId
+    /**
+     * Called when a dispute is detected on-chain (close_start has been called).
+     * Use this to trigger a close response before the waiting period elapses.
+     */
+    onDisputeDetected?: (state: ChannelState) => void
     /** Custom Soroban RPC URL. */
     rpcUrl?: string
     /**

--- a/sdk/src/channel/server/State.test.ts
+++ b/sdk/src/channel/server/State.test.ts
@@ -1,0 +1,203 @@
+import { Address, Keypair, xdr } from '@stellar/stellar-sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+// Hoisted mock stubs
+const mockGetAccount = vi.fn()
+const mockSimulateTransaction = vi.fn()
+const mockGetLedgerEntries = vi.fn()
+const mockGetLatestLedger = vi.fn()
+
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>()
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: vi.fn().mockImplementation(() => ({
+        getAccount: mockGetAccount,
+        simulateTransaction: mockSimulateTransaction,
+        getLedgerEntries: mockGetLedgerEntries,
+        getLatestLedger: mockGetLatestLedger,
+      })),
+    },
+  }
+})
+
+const { getChannelState } = await import('./State.js')
+
+const SOURCE_ACCOUNT = Keypair.random().publicKey()
+const CHANNEL_ADDRESS = 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526'
+const TOKEN_ADDRESS = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
+const FUNDER_ADDRESS = Keypair.random().publicKey()
+const RECIPIENT_ADDRESS = Keypair.random().publicKey()
+
+// Default account stub
+mockGetAccount.mockResolvedValue({
+  accountId: () => SOURCE_ACCOUNT,
+  sequenceNumber: () => '0',
+  sequence: () => '0',
+  incrementSequenceNumber: () => {},
+})
+
+function makeI128ScVal(amount: bigint): xdr.ScVal {
+  const lo = amount & 0xFFFFFFFFFFFFFFFFn
+  const hi = amount >> 64n
+  return xdr.ScVal.scvI128(
+    new xdr.Int128Parts({ lo: xdr.Uint64.fromString(lo.toString()), hi: xdr.Int64.fromString(hi.toString()) }),
+  )
+}
+
+function makeAddressScVal(address: string): xdr.ScVal {
+  return Address.fromString(address).toScVal()
+}
+
+function setupSimulations(opts: {
+  balance: bigint
+  waitingPeriod: number
+  token: string
+  from: string
+  to: string
+}) {
+  const calls: xdr.ScVal[] = [
+    makeI128ScVal(opts.balance),
+    xdr.ScVal.scvU32(opts.waitingPeriod),
+    makeAddressScVal(opts.token),
+    makeAddressScVal(opts.from),
+    makeAddressScVal(opts.to),
+  ]
+
+  let callIndex = 0
+  mockSimulateTransaction.mockImplementation(() => ({
+    result: { retval: calls[callIndex++] },
+    transactionData: 'mock',
+  }))
+}
+
+function makeLedgerEntryWithCloseEffective(ledgerValue: number) {
+  // Build instance storage with CloseEffectiveAtLedger
+  const storage = [
+    new xdr.ScMapEntry({
+      key: xdr.ScVal.scvVec([xdr.ScVal.scvSymbol('CloseEffectiveAtLedger')]),
+      val: xdr.ScVal.scvU32(ledgerValue),
+    }),
+  ]
+
+  const instance = new xdr.ScContractInstance({
+    executable: xdr.ContractExecutable.contractExecutableWasm(
+      Buffer.alloc(32),
+    ),
+    storage,
+  })
+
+  const contractData = new xdr.ContractDataEntry({
+    ext: xdr.ExtensionPoint.fromXDR(Buffer.alloc(4, 0), 'raw'),
+    contract: Address.fromString(CHANNEL_ADDRESS).toScAddress(),
+    key: xdr.ScVal.scvLedgerKeyContractInstance(),
+    durability: xdr.ContractDataDurability.persistent(),
+    val: xdr.ScVal.scvContractInstance(instance),
+  })
+
+  const entryData = xdr.LedgerEntryData.contractData(contractData)
+
+  return { entries: [{ val: entryData, lastModifiedLedgerSeq: 100 }] }
+}
+
+function makeLedgerEntryWithoutCloseEffective() {
+  const instance = new xdr.ScContractInstance({
+    executable: xdr.ContractExecutable.contractExecutableWasm(
+      Buffer.alloc(32),
+    ),
+    storage: [],
+  })
+
+  const contractData = new xdr.ContractDataEntry({
+    ext: xdr.ExtensionPoint.fromXDR(Buffer.alloc(4, 0), 'raw'),
+    contract: Address.fromString(CHANNEL_ADDRESS).toScAddress(),
+    key: xdr.ScVal.scvLedgerKeyContractInstance(),
+    durability: xdr.ContractDataDurability.persistent(),
+    val: xdr.ScVal.scvContractInstance(instance),
+  })
+
+  const entryData = xdr.LedgerEntryData.contractData(contractData)
+
+  return { entries: [{ val: entryData, lastModifiedLedgerSeq: 100 }] }
+}
+
+describe('getChannelState', () => {
+  it('returns channel state from on-chain getters', async () => {
+    setupSimulations({
+      balance: 10_000_000n,
+      waitingPeriod: 1000,
+      token: TOKEN_ADDRESS,
+      from: FUNDER_ADDRESS,
+      to: RECIPIENT_ADDRESS,
+    })
+    mockGetLedgerEntries.mockResolvedValueOnce(makeLedgerEntryWithoutCloseEffective())
+    mockGetLatestLedger.mockResolvedValueOnce({ sequence: 5000 })
+
+    const state = await getChannelState({
+      channel: CHANNEL_ADDRESS,
+      sourceAccount: SOURCE_ACCOUNT,
+    })
+
+    expect(state.balance).toBe(10_000_000n)
+    expect(state.refundWaitingPeriod).toBe(1000)
+    expect(state.token).toBe(TOKEN_ADDRESS)
+    expect(state.from).toBe(FUNDER_ADDRESS)
+    expect(state.to).toBe(RECIPIENT_ADDRESS)
+    expect(state.closeEffectiveAtLedger).toBeNull()
+    expect(state.currentLedger).toBe(5000)
+  })
+
+  it('detects close_start via CloseEffectiveAtLedger in instance storage', async () => {
+    setupSimulations({
+      balance: 5_000_000n,
+      waitingPeriod: 1000,
+      token: TOKEN_ADDRESS,
+      from: FUNDER_ADDRESS,
+      to: RECIPIENT_ADDRESS,
+    })
+    mockGetLedgerEntries.mockResolvedValueOnce(makeLedgerEntryWithCloseEffective(6000))
+    mockGetLatestLedger.mockResolvedValueOnce({ sequence: 5500 })
+
+    const state = await getChannelState({
+      channel: CHANNEL_ADDRESS,
+      sourceAccount: SOURCE_ACCOUNT,
+    })
+
+    expect(state.closeEffectiveAtLedger).toBe(6000)
+    expect(state.currentLedger).toBe(5500)
+  })
+
+  it('returns null closeEffectiveAtLedger when no entries', async () => {
+    setupSimulations({
+      balance: 1_000_000n,
+      waitingPeriod: 500,
+      token: TOKEN_ADDRESS,
+      from: FUNDER_ADDRESS,
+      to: RECIPIENT_ADDRESS,
+    })
+    mockGetLedgerEntries.mockResolvedValueOnce({ entries: [] })
+    mockGetLatestLedger.mockResolvedValueOnce({ sequence: 1000 })
+
+    const state = await getChannelState({
+      channel: CHANNEL_ADDRESS,
+      sourceAccount: SOURCE_ACCOUNT,
+    })
+
+    expect(state.closeEffectiveAtLedger).toBeNull()
+  })
+
+  it('throws on simulation failure', async () => {
+    mockSimulateTransaction.mockResolvedValue({
+      error: 'simulation failed',
+    })
+
+    await expect(
+      getChannelState({
+        channel: CHANNEL_ADDRESS,
+        sourceAccount: SOURCE_ACCOUNT,
+      }),
+    ).rejects.toThrow('Failed to simulate')
+  })
+})

--- a/sdk/src/channel/server/State.ts
+++ b/sdk/src/channel/server/State.ts
@@ -1,0 +1,237 @@
+import {
+  Address,
+  Contract,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+  xdr,
+} from '@stellar/stellar-sdk'
+import {
+  NETWORK_PASSPHRASE,
+  SOROBAN_RPC_URLS,
+  type NetworkId,
+} from '../../constants.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ChannelState = {
+  /** Current token balance held in the channel contract. */
+  balance: bigint
+  /** The refund waiting period in ledgers. */
+  refundWaitingPeriod: number
+  /** Token contract address. */
+  token: string
+  /** Funder address. */
+  from: string
+  /** Recipient address. */
+  to: string
+  /**
+   * If set, the ledger sequence at which close becomes effective. This means
+   * either `close_start` has been called (dispute) or `close` has settled.
+   * If the current ledger is past this value, the funder can call `refund`.
+   */
+  closeEffectiveAtLedger: number | null
+  /** Current ledger sequence at the time of the query. */
+  currentLedger: number
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Query the on-chain state of a one-way payment channel contract.
+ *
+ * This calls the contract's public getter functions via simulation
+ * (no transaction fees) and reads instance storage for dispute status.
+ *
+ * @example
+ * ```ts
+ * import { getChannelState } from 'stellar-mpp-sdk/channel/server'
+ *
+ * const state = await getChannelState({
+ *   channel: 'CABC...',
+ *   sourceAccount: 'GABC...',
+ * })
+ *
+ * if (state.closeEffectiveAtLedger != null) {
+ *   console.log('Channel is closing/closed!')
+ * }
+ * ```
+ */
+export async function getChannelState(
+  parameters: getChannelState.Parameters,
+): Promise<ChannelState> {
+  const {
+    channel: channelAddress,
+    network = 'testnet',
+    rpcUrl,
+    sourceAccount,
+  } = parameters
+
+  const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
+  const networkPassphrase = NETWORK_PASSPHRASE[network]
+  const server = new rpc.Server(resolvedRpcUrl)
+
+  const contract = new Contract(channelAddress)
+  const account = await server.getAccount(sourceAccount)
+
+  async function simulateGetter(fnName: string, ...args: xdr.ScVal[]) {
+    const call = contract.call(fnName, ...args)
+    const tx = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase,
+    })
+      .addOperation(call)
+      .setTimeout(30)
+      .build()
+
+    const result = await server.simulateTransaction(tx)
+    if (!rpc.Api.isSimulationSuccess(result)) {
+      const errorMsg =
+        'error' in result ? String(result.error) : 'unknown'
+      throw new Error(
+        `Failed to simulate ${fnName} on channel ${channelAddress}: ${errorMsg}`,
+      )
+    }
+    return result.result?.retval
+  }
+
+  // Run getter simulations in parallel
+  const [balanceVal, waitingPeriodVal, tokenVal, fromVal, toVal] =
+    await Promise.all([
+      simulateGetter('balance'),
+      simulateGetter('refund_waiting_period'),
+      simulateGetter('token'),
+      simulateGetter('from'),
+      simulateGetter('to'),
+    ])
+
+  const balance = scValToI128(balanceVal!)
+  const refundWaitingPeriod = balanceVal
+    ? waitingPeriodVal!.u32()
+    : 0
+  const token = Address.fromScVal(tokenVal!).toString()
+  const from = Address.fromScVal(fromVal!).toString()
+  const to = Address.fromScVal(toVal!).toString()
+
+  // Read CloseEffectiveAtLedger from contract instance storage.
+  // The contract uses DataKey::CloseEffectiveAtLedger (enum variant index 5)
+  // stored in instance storage.
+  const closeEffectiveAtLedger = await readCloseEffectiveAtLedger(
+    server,
+    channelAddress,
+  )
+
+  const latestLedger = await server.getLatestLedger()
+
+  return {
+    balance,
+    refundWaitingPeriod,
+    token,
+    from,
+    to,
+    closeEffectiveAtLedger,
+    currentLedger: latestLedger.sequence,
+  }
+}
+
+export declare namespace getChannelState {
+  type Parameters = {
+    /** Channel contract address (C...). */
+    channel: string
+    /** Stellar network. @default 'testnet' */
+    network?: NetworkId
+    /** Custom Soroban RPC URL. */
+    rpcUrl?: string
+    /** Funded Stellar account address (G...) used as the source for simulations. */
+    sourceAccount: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the CloseEffectiveAtLedger entry from the contract's instance storage.
+ *
+ * The contract's `DataKey` enum:
+ * ```rust
+ * enum DataKey { Token, From, CommitmentKey, To, RefundWaitingPeriod, CloseEffectiveAtLedger }
+ * ```
+ * Each variant is encoded as `ScVal::Vec([ScVal::Symbol(variant_name)])` in Soroban
+ * for enum variants without data.
+ *
+ * We look for the `CloseEffectiveAtLedger` key in the contract's instance storage.
+ */
+async function readCloseEffectiveAtLedger(
+  server: rpc.Server,
+  channelAddress: string,
+): Promise<number | null> {
+  try {
+    // Build the LedgerKey for the contract's instance entry
+    const contractId = Address.fromString(channelAddress)
+    const instanceKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: contractId.toScAddress(),
+        key: xdr.ScVal.scvLedgerKeyContractInstance(),
+        durability: xdr.ContractDataDurability.persistent(),
+      }),
+    )
+
+    const response = await server.getLedgerEntries(instanceKey)
+    if (!response.entries || response.entries.length === 0) {
+      return null
+    }
+
+    const entry = response.entries[0]
+    const contractData = entry.val.contractData()
+    const instance = contractData.val().instance()
+    const storage = instance.storage()
+
+    if (!storage) return null
+
+    // Search for the CloseEffectiveAtLedger key in the instance storage map.
+    // Soroban encodes simple enum variants as ScVal::Vec([ScVal::Symbol(name)])
+    for (const entry of storage) {
+      const key = entry.key()
+      // Check if this key matches DataKey::CloseEffectiveAtLedger
+      if (isEnumVariant(key, 'CloseEffectiveAtLedger')) {
+        const val = entry.val()
+        return val.u32()
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+/** Check if an ScVal is a Soroban enum variant with the given name. */
+function isEnumVariant(scVal: xdr.ScVal, name: string): boolean {
+  try {
+    if (scVal.switch().value === xdr.ScValType.scvVec().value) {
+      const vec = scVal.vec()!
+      if (
+        vec.length === 1 &&
+        vec[0].switch().value === xdr.ScValType.scvSymbol().value
+      ) {
+        return vec[0].sym().toString() === name
+      }
+    }
+  } catch {
+    // not the shape we expected
+  }
+  return false
+}
+
+function scValToI128(val: xdr.ScVal): bigint {
+  const i128 = val.i128()
+  const hi = BigInt(i128.hi().toString())
+  const lo = BigInt(i128.lo().toString())
+  return (hi << 64n) | lo
+}

--- a/sdk/src/channel/server/State.ts
+++ b/sdk/src/channel/server/State.ts
@@ -2,7 +2,6 @@ import {
   Address,
   Contract,
   TransactionBuilder,
-  nativeToScVal,
   rpc,
   xdr,
 } from '@stellar/stellar-sdk'
@@ -110,9 +109,12 @@ export async function getChannelState(
     ])
 
   const balance = scValToI128(balanceVal!)
-  const refundWaitingPeriod = balanceVal
-    ? waitingPeriodVal!.u32()
-    : 0
+  if (!waitingPeriodVal) {
+    throw new Error(
+      `Failed to simulate refund_waiting_period on channel ${channelAddress}: missing return value`,
+    )
+  }
+  const refundWaitingPeriod = waitingPeriodVal.u32()
   const token = Address.fromScVal(tokenVal!).toString()
   const from = Address.fromScVal(fromVal!).toString()
   const to = Address.fromScVal(toVal!).toString()

--- a/sdk/src/channel/server/Watcher.test.ts
+++ b/sdk/src/channel/server/Watcher.test.ts
@@ -1,0 +1,314 @@
+import { xdr } from '@stellar/stellar-sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetEvents = vi.fn()
+const mockGetLatestLedger = vi.fn()
+
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>()
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: vi.fn().mockImplementation(() => ({
+        getEvents: mockGetEvents,
+        getLatestLedger: mockGetLatestLedger,
+      })),
+    },
+  }
+})
+
+const { watchChannel } = await import('./Watcher.js')
+
+const CHANNEL_ADDRESS = 'CBU3P5BAU6CYGPAVY7TGGGNEPCS7H73IA3L677Z3CFZSGFYB7UFK4IMS'
+
+function makeSymbolScVal(name: string): xdr.ScVal {
+  return xdr.ScVal.scvSymbol(name)
+}
+
+function makeI128ScVal(amount: bigint): xdr.ScVal {
+  const hi = amount >> 64n
+  const lo = amount & ((1n << 64n) - 1n)
+  return xdr.ScVal.scvI128(
+    new xdr.Int128Parts({
+      hi: xdr.Int64.fromString(hi.toString()),
+      lo: xdr.Uint64.fromString(lo.toString()),
+    }),
+  )
+}
+
+function makeEvent(options: {
+  topicName: string
+  value?: xdr.ScVal
+  txHash?: string
+  ledger?: number
+}) {
+  return {
+    id: `event-${Math.random()}`,
+    type: 'contract',
+    ledger: options.ledger ?? 1000,
+    ledgerClosedAt: '2026-03-19T00:00:00Z',
+    transactionIndex: 0,
+    operationIndex: 0,
+    inSuccessfulContractCall: true,
+    txHash: options.txHash ?? 'abc123',
+    topic: [makeSymbolScVal(options.topicName)],
+    value: options.value ?? xdr.ScVal.scvVoid(),
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockGetLatestLedger.mockResolvedValue({ id: 'latest', sequence: 5000, protocolVersion: '22' })
+  mockGetEvents.mockResolvedValue({ events: [], cursor: '' })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('watchChannel', () => {
+  it('calls getLatestLedger on first poll to determine startLedger', async () => {
+    const events: unknown[] = []
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      onEvent: (e) => events.push(e),
+      intervalMs: 1000,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockGetLatestLedger).toHaveBeenCalledOnce()
+    expect(mockGetEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ startLedger: 5000 }),
+    )
+
+    stop()
+  })
+
+  it('parses a close event with amount', async () => {
+    const events: unknown[] = []
+
+    mockGetEvents.mockResolvedValueOnce({
+      events: [
+        makeEvent({
+          topicName: 'close',
+          value: makeI128ScVal(5_000_000n),
+          txHash: 'close-hash',
+          ledger: 1001,
+        }),
+      ],
+      cursor: 'cursor-1',
+    })
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      onEvent: (e) => events.push(e),
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      type: 'close',
+      amount: 5_000_000n,
+      txHash: 'close-hash',
+      ledger: 1001,
+      ledgerClosedAt: '2026-03-19T00:00:00Z',
+    })
+
+    stop()
+  })
+
+  it('parses a close_start event', async () => {
+    const events: unknown[] = []
+
+    mockGetEvents.mockResolvedValueOnce({
+      events: [
+        makeEvent({
+          topicName: 'close_start',
+          txHash: 'close-start-hash',
+          ledger: 2000,
+        }),
+      ],
+      cursor: 'cursor-2',
+    })
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      onEvent: (e) => events.push(e),
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      type: 'close_start',
+      txHash: 'close-start-hash',
+      ledger: 2000,
+      ledgerClosedAt: '2026-03-19T00:00:00Z',
+    })
+
+    stop()
+  })
+
+  it('parses refund and top_up events', async () => {
+    const events: unknown[] = []
+
+    mockGetEvents.mockResolvedValueOnce({
+      events: [
+        makeEvent({
+          topicName: 'refund',
+          value: makeI128ScVal(3_000_000n),
+          txHash: 'refund-hash',
+        }),
+        makeEvent({
+          topicName: 'top_up',
+          value: makeI128ScVal(10_000_000n),
+          txHash: 'topup-hash',
+        }),
+      ],
+      cursor: 'cursor-3',
+    })
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      onEvent: (e) => events.push(e),
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({ type: 'refund', amount: 3_000_000n })
+    expect(events[1]).toMatchObject({ type: 'top_up', amount: 10_000_000n })
+
+    stop()
+  })
+
+  it('ignores unknown event topics', async () => {
+    const events: unknown[] = []
+
+    mockGetEvents.mockResolvedValueOnce({
+      events: [
+        makeEvent({ topicName: 'some_other_event' }),
+      ],
+      cursor: 'cursor-4',
+    })
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      onEvent: (e) => events.push(e),
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(events).toHaveLength(0)
+
+    stop()
+  })
+
+  it('uses cursor for subsequent polls', async () => {
+    mockGetEvents
+      .mockResolvedValueOnce({
+        events: [makeEvent({ topicName: 'close_start' })],
+        cursor: 'cursor-after-first',
+      })
+      .mockResolvedValueOnce({
+        events: [],
+        cursor: '',
+      })
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      intervalMs: 1000,
+      onEvent: () => {},
+    })
+
+    // First poll (immediate)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockGetEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ startLedger: 5000 }),
+    )
+
+    // Second poll (after interval)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(mockGetEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cursor: 'cursor-after-first' }),
+    )
+
+    stop()
+  })
+
+  it('calls onError when polling fails', async () => {
+    const errors: Error[] = []
+    mockGetEvents.mockRejectedValueOnce(new Error('RPC down'))
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      onEvent: () => {},
+      onError: (e) => errors.push(e),
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toBe('RPC down')
+
+    stop()
+  })
+
+  it('stops polling when stop() is called', async () => {
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      intervalMs: 1000,
+      onEvent: () => {},
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockGetEvents).toHaveBeenCalledTimes(1)
+
+    stop()
+
+    await vi.advanceTimersByTimeAsync(5000)
+    // No additional polls after stop
+    expect(mockGetEvents).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops polling when AbortSignal is triggered', async () => {
+    const controller = new AbortController()
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      intervalMs: 1000,
+      onEvent: () => {},
+      signal: controller.signal,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockGetEvents).toHaveBeenCalledTimes(1)
+
+    controller.abort()
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(mockGetEvents).toHaveBeenCalledTimes(1)
+
+    stop()
+  })
+
+  it('does not start if AbortSignal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      onEvent: () => {},
+      signal: controller.signal,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockGetEvents).not.toHaveBeenCalled()
+
+    stop()
+  })
+})

--- a/sdk/src/channel/server/Watcher.ts
+++ b/sdk/src/channel/server/Watcher.ts
@@ -58,7 +58,8 @@ export function watchChannel(parameters: watchChannel.Parameters): () => void {
 
   let cursor: string | undefined
   let startLedger: number | undefined
-  let timer: ReturnType<typeof setInterval> | undefined
+  let timerResolve: (() => void) | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
   let stopped = false
 
   async function init() {
@@ -93,6 +94,9 @@ export function watchChannel(parameters: watchChannel.Parameters): () => void {
 
       const response = await server.getEvents(request)
 
+      // Guard: do not emit events after shutdown
+      if (stopped) return
+
       for (const event of response.events) {
         const parsed = parseEvent(event)
         if (parsed) {
@@ -100,9 +104,9 @@ export function watchChannel(parameters: watchChannel.Parameters): () => void {
         }
       }
 
-      if (response.events.length > 0) {
-        cursor = response.cursor
-      }
+      // Always advance the cursor so subsequent polls don't re-scan
+      // the same ledger range even when there are no matching events.
+      cursor = response.cursor
     } catch (error) {
       if (!stopped) {
         onError?.(error instanceof Error ? error : new Error(String(error)))
@@ -113,7 +117,27 @@ export function watchChannel(parameters: watchChannel.Parameters): () => void {
   function stop() {
     stopped = true
     if (timer != null) {
-      clearInterval(timer)
+      clearTimeout(timer)
+      timer = undefined
+    }
+    // Unblock the sleep promise so the loop can exit promptly
+    timerResolve?.()
+    timerResolve = undefined
+  }
+
+  async function runLoop() {
+    while (!stopped) {
+      await poll()
+      if (stopped) break
+      await new Promise<void>((resolve) => {
+        timerResolve = resolve
+        timer = setTimeout(() => {
+          timerResolve = undefined
+          timer = undefined
+          resolve()
+        }, intervalMs)
+      })
+      timerResolve = undefined
       timer = undefined
     }
   }
@@ -126,9 +150,8 @@ export function watchChannel(parameters: watchChannel.Parameters): () => void {
     signal.addEventListener('abort', stop, { once: true })
   }
 
-  // Start polling immediately, then on interval
-  void poll()
-  timer = setInterval(() => void poll(), intervalMs)
+  // Start the polling loop immediately
+  void runLoop()
 
   return stop
 }

--- a/sdk/src/channel/server/Watcher.ts
+++ b/sdk/src/channel/server/Watcher.ts
@@ -1,0 +1,201 @@
+import { rpc, xdr } from '@stellar/stellar-sdk'
+import {
+  SOROBAN_RPC_URLS,
+  type NetworkId,
+} from '../../constants.js'
+
+// ---------------------------------------------------------------------------
+// Event types
+// ---------------------------------------------------------------------------
+
+export type ChannelEvent =
+  | { type: 'close'; amount: bigint; txHash: string; ledger: number; ledgerClosedAt: string }
+  | { type: 'close_start'; txHash: string; ledger: number; ledgerClosedAt: string }
+  | { type: 'refund'; amount: bigint; txHash: string; ledger: number; ledgerClosedAt: string }
+  | { type: 'top_up'; amount: bigint; txHash: string; ledger: number; ledgerClosedAt: string }
+
+const KNOWN_TOPICS = new Set(['close', 'close_start', 'refund', 'top_up'])
+
+// ---------------------------------------------------------------------------
+// Watcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Polls Soroban RPC for contract events on a one-way payment channel.
+ *
+ * @returns A stop function that cancels the polling loop.
+ *
+ * @example
+ * ```ts
+ * import { watchChannel } from 'stellar-mpp-sdk/channel/server'
+ *
+ * const stop = watchChannel({
+ *   channel: 'CABC...',
+ *   onEvent(event) {
+ *     if (event.type === 'close_start') {
+ *       console.log('Dispute opened — respond before timeout!')
+ *     }
+ *   },
+ * })
+ *
+ * // Later, stop watching:
+ * stop()
+ * ```
+ */
+export function watchChannel(parameters: watchChannel.Parameters): () => void {
+  const {
+    channel,
+    network = 'testnet',
+    rpcUrl,
+    intervalMs = 5_000,
+    onEvent,
+    onError,
+    signal,
+  } = parameters
+
+  const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
+  const server = new rpc.Server(resolvedRpcUrl)
+
+  let cursor: string | undefined
+  let startLedger: number | undefined
+  let timer: ReturnType<typeof setInterval> | undefined
+  let stopped = false
+
+  async function init() {
+    if (startLedger != null) return
+    const latest = await server.getLatestLedger()
+    startLedger = latest.sequence
+  }
+
+  async function poll() {
+    if (stopped) return
+
+    try {
+      await init()
+
+      const request: rpc.Api.GetEventsRequest = cursor
+        ? {
+            filters: [{
+              type: 'contract' as const,
+              contractIds: [channel],
+              topics: [['*']],
+            }],
+            cursor,
+          }
+        : {
+            filters: [{
+              type: 'contract' as const,
+              contractIds: [channel],
+              topics: [['*']],
+            }],
+            startLedger: startLedger!,
+          }
+
+      const response = await server.getEvents(request)
+
+      for (const event of response.events) {
+        const parsed = parseEvent(event)
+        if (parsed) {
+          onEvent(parsed)
+        }
+      }
+
+      if (response.events.length > 0) {
+        cursor = response.cursor
+      }
+    } catch (error) {
+      if (!stopped) {
+        onError?.(error instanceof Error ? error : new Error(String(error)))
+      }
+    }
+  }
+
+  function stop() {
+    stopped = true
+    if (timer != null) {
+      clearInterval(timer)
+      timer = undefined
+    }
+  }
+
+  if (signal) {
+    if (signal.aborted) {
+      stopped = true
+      return stop
+    }
+    signal.addEventListener('abort', stop, { once: true })
+  }
+
+  // Start polling immediately, then on interval
+  void poll()
+  timer = setInterval(() => void poll(), intervalMs)
+
+  return stop
+}
+
+export declare namespace watchChannel {
+  interface Parameters {
+    /** Channel contract address (C...). */
+    channel: string
+    /** Network identifier. Defaults to 'testnet'. */
+    network?: NetworkId
+    /** Custom Soroban RPC URL. */
+    rpcUrl?: string
+    /** Polling interval in milliseconds. Defaults to 5000. */
+    intervalMs?: number
+    /** Called for each channel event. */
+    onEvent: (event: ChannelEvent) => void
+    /** Called when a polling error occurs. */
+    onError?: (error: Error) => void
+    /** AbortSignal for clean shutdown. */
+    signal?: AbortSignal
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event parsing
+// ---------------------------------------------------------------------------
+
+function parseEvent(event: rpc.Api.EventResponse): ChannelEvent | null {
+  if (!event.topic || event.topic.length === 0) return null
+
+  const topicName = decodeSymbol(event.topic[0])
+  if (!topicName || !KNOWN_TOPICS.has(topicName)) return null
+
+  const { txHash, ledger, ledgerClosedAt } = event
+
+  switch (topicName) {
+    case 'close':
+      return { type: 'close', amount: decodeI128(event.value), txHash, ledger, ledgerClosedAt }
+    case 'close_start':
+      return { type: 'close_start', txHash, ledger, ledgerClosedAt }
+    case 'refund':
+      return { type: 'refund', amount: decodeI128(event.value), txHash, ledger, ledgerClosedAt }
+    case 'top_up':
+      return { type: 'top_up', amount: decodeI128(event.value), txHash, ledger, ledgerClosedAt }
+    default:
+      return null
+  }
+}
+
+function decodeSymbol(scVal: xdr.ScVal): string | null {
+  try {
+    if (scVal.switch().value === xdr.ScValType.scvSymbol().value) {
+      return scVal.sym().toString()
+    }
+  } catch {
+    // Not a symbol
+  }
+  return null
+}
+
+function decodeI128(scVal: xdr.ScVal): bigint {
+  try {
+    const i128 = scVal.i128()
+    const hi = BigInt(i128.hi().toString())
+    const lo = BigInt(i128.lo().toString())
+    return (hi << 64n) | lo
+  } catch {
+    return 0n
+  }
+}

--- a/sdk/src/channel/server/index.ts
+++ b/sdk/src/channel/server/index.ts
@@ -1,3 +1,7 @@
 export { channel, close } from './Channel.js'
+export { getChannelState } from './State.js'
+export type { ChannelState } from './State.js'
 export { stellar } from './Methods.js'
+export { watchChannel } from './Watcher.js'
+export type { ChannelEvent } from './Watcher.js'
 export { Expires, Mppx, Store } from 'mppx/server'


### PR DESCRIPTION
## Summary

Adds action-discriminated credential payloads, on-chain state query utilities, lazy dispute detection during verify, and a Soroban event watcher — aligning the channel SDK with Tempo's `SessionCredentialPayload` pattern.

The key insight (from Tempo's mpp-rs implementation) is that the server doesn't need a background poller as the primary mechanism for state awareness. Instead:

1. **Lazy cache during verify** — Each incoming voucher refreshes the server's view of on-chain state
2. **Standalone utilities** — The server can query state on-demand whenever it wants
3. **Close as a protocol action** — The client requests close through the normal 402 credential flow, not a separate API

## Changes

### Credential Actions (`Methods.ts`, `client/Channel.ts`)

- Credential payload is now a `z.union` with discriminated `action` field: `'voucher' | 'close'`
- Client context schema accepts optional `action` (defaults to `'voucher'`)
- Serialized credential payload includes the `action` field

### Server Verify Dispatch (`server/Channel.ts`)

- New `closeKey` parameter (optional) for signing close transactions on-chain
- Verify dispatches on `payload.action`:
  - **voucher**: existing verification logic (unchanged)
  - **close**: same signature verification, then submits close tx on-chain using `closeKey`, marks channel as finalized in store
- New `checkOnChainState` flag (default `false`): when enabled, each verify call lazily reads on-chain state via `getChannelState()`, caching results in store
- New `onDisputeDetected` callback: fires when `close_start` is detected on-chain, giving the server a chance to respond with a close before the waiting period elapses
- Rejects vouchers if the channel is already closed (effective ledger reached)
- Network errors during on-chain check are non-fatal — verify continues normally

### On-Chain State Utility (`server/State.ts`)

`getChannelState()` reads contract state via simulation + ledger entry inspection:
- Public getters: `balance`, `refund_waiting_period`, `token`, `from`, `to`
- Instance storage: reads `CloseEffectiveAtLedger` via `getLedgerEntries` to detect dispute/close status
- Returns typed `ChannelState` object callable anytime by the server, outside of verify

### Event Watcher (`server/Watcher.ts`)

`watchChannel()` polls Soroban RPC `getEvents` for contract events:
- Parses `close`, `close_start`, `refund`, `top_up` events
- Configurable polling interval, AbortSignal support
- Supplementary safety net alongside lazy state detection

### Exports (`server/index.ts`)

New exports: `getChannelState`, `ChannelState`, `watchChannel`, `ChannelEvent`

## Tests

- **111 total tests passing** (up from 88)
- 4 new `State.test.ts` tests (on-chain getters, dispute detection via instance storage, error handling)
- 5 new dispute guard tests in `Channel.test.ts` (closed channel rejection, dispute callback, network error resilience, state caching, opt-out)
- 1 new `closeKey` acceptance test
- 10 new `Watcher.test.ts` tests (event parsing, polling lifecycle, error handling, cursor management)
- Updated all existing credential payloads with `action` field
- 1 new `Methods.test.ts` test for unknown action rejection
