### PR TITLE
Add prepare script for git-hosted installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "tsc",
     "build": "tsc",
     "check:types": "tsc --noEmit",
     "test": "vitest",


### PR DESCRIPTION
## Summary

- Adds `"prepare": "tsc"` to the scripts section of package.json
- When installing this package from a git URL (e.g., `"stellar-mpp-sdk": "github:stellar-experimental/stellar-mpp-sdk"`), npm/pnpm checks for a `prepare` script
- If `prepare` exists, devDependencies are installed and the script runs before the package is packed
- Without it, the `"files": ["dist"]` filter yields an empty package since `dist/` is gitignored and never built
- This one-line addition enables clean git-hosted installs

## Test plan

- [ ] `npm pack` still produces a tarball with only `dist/` contents
- [ ] `pnpm add github:stellar-experimental/stellar-mpp-sdk` resolves with built `dist/` files
- [ ] `npm install github:stellar-experimental/stellar-mpp-sdk` resolves with built `dist/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)