### PR TITLE
fix: address Nemesis audit findings (issue #205)

### DIFF
--- a/sdk/src/Methods.test.ts
+++ b/sdk/src/Methods.test.ts
@@ -27,6 +27,11 @@ describe('toBaseUnits', () => {
   it('pads fewer decimals', () => {
     expect(toBaseUnits('1.5', 7)).toBe('15000000')
   })
+
+  it('handles negative amounts correctly (NM-006)', () => {
+    expect(toBaseUnits('-1.5', 7)).toBe('-15000000')
+    expect(toBaseUnits('-0.01', 7)).toBe('-100000')
+  })
 })
 
 describe('fromBaseUnits', () => {
@@ -41,6 +46,16 @@ describe('fromBaseUnits', () => {
   it('roundtrips', () => {
     const base = toBaseUnits('42.1234567', 7)
     expect(fromBaseUnits(base, 7)).toBe('42.1234567')
+  })
+
+  it('handles negative amounts correctly (NM-006)', () => {
+    expect(fromBaseUnits('-15000000', 7)).toBe('-1.5000000')
+    expect(fromBaseUnits('-5000000', 7)).toBe('-0.5000000')
+  })
+
+  it('roundtrips negative amounts (NM-006)', () => {
+    const base = toBaseUnits('-1.5', 7)
+    expect(fromBaseUnits(base, 7)).toBe('-1.5000000')
   })
 })
 

--- a/sdk/src/Methods.ts
+++ b/sdk/src/Methods.ts
@@ -70,6 +70,9 @@ export const charge = Method.from({
  * ```
  */
 export function toBaseUnits(amount: string, decimals: number): string {
+  if (amount.startsWith('-')) {
+    return '-' + toBaseUnits(amount.slice(1), decimals)
+  }
   const [whole = '0', frac = ''] = amount.split('.')
   if (decimals === 0) return BigInt(whole).toString()
   const paddedFrac = frac.padEnd(decimals, '0').slice(0, decimals)
@@ -86,6 +89,9 @@ export function toBaseUnits(amount: string, decimals: number): string {
  */
 export function fromBaseUnits(baseUnits: string, decimals: number): string {
   const bi = BigInt(baseUnits)
+  if (bi < 0n) {
+    return '-' + fromBaseUnits((-bi).toString(), decimals)
+  }
   const divisor = 10n ** BigInt(decimals)
   const whole = (bi / divisor).toString()
   const remainder = (bi % divisor).toString().padStart(decimals, '0')

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -558,17 +558,11 @@ describe('stellar server channel dispute detection', () => {
     expect(onDisputeDetected).toHaveBeenCalledWith(disputeState)
   })
 
-  it('continues normally when on-chain check fails (network error)', async () => {
+  it('rejects voucher when on-chain check fails (network error)', async () => {
     mockGetChannelState.mockRejectedValueOnce(new Error('network timeout'))
 
-    const commitmentBytes = Buffer.from('network-error-test')
-    mockSimulateTransaction.mockResolvedValueOnce(
-      successSimResult(commitmentBytes),
-    )
-
-    const credential = makeSignedCredential({
-      commitmentBytes,
-      cumulativeAmount: 1000000n,
+    const credential = makeCredential({
+      amount: '1000000',
       challengeAmount: '1000000',
     })
 
@@ -579,12 +573,13 @@ describe('stellar server channel dispute detection', () => {
       sourceAccount: MOCK_SOURCE_KEY.publicKey(),
     })
 
-    // Should still succeed — on-chain check failure is non-fatal
-    const receipt = await method.verify({
-      credential: credential as any,
-      request: credential.challenge.request,
-    })
-    expect(receipt.status).toBe('success')
+    // NM-005: Fail closed — on-chain check failure now rejects the voucher
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('On-chain state check failed')
   })
 
   it('caches on-chain state in store', async () => {
@@ -679,5 +674,63 @@ describe('stellar server channel dispute detection', () => {
         request: credential.challenge.request,
       }),
     ).rejects.toThrow('checkOnChainState requires sourceAccount to be set')
+  })
+
+  it('rejects voucher after channel finalization (NM-001)', async () => {
+    const store = Store.memory()
+    await store.put(`stellar:channel:finalized:${CHANNEL_ADDRESS}`, {
+      finalizedAt: new Date().toISOString(),
+      txHash: 'abc123',
+      amount: '5000000',
+    })
+
+    const credential = makeCredential({
+      amount: '1000000',
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      store,
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('Channel has been finalized')
+  })
+
+  it('rejects commitment that exceeds on-chain balance (NM-003)', async () => {
+    mockGetChannelState.mockResolvedValueOnce({
+      balance: 500000n, // less than commitment
+      refundWaitingPeriod: 1000,
+      token: 'CTOKEN...',
+      from: 'GFROM...',
+      to: 'GTO...',
+      closeEffectiveAtLedger: null,
+      currentLedger: 4000,
+    })
+
+    const credential = makeCredential({
+      amount: '1000000',
+      challengeAmount: '1000000',
+    })
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      commitmentKey: COMMITMENT_KEY,
+      checkOnChainState: true,
+      sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+    })
+
+    await expect(
+      method.verify({
+        credential: credential as any,
+        request: credential.challenge.request,
+      }),
+    ).rejects.toThrow('exceeds channel balance')
   })
 })

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -124,7 +124,21 @@ export function channel(parameters: channel.Parameters) {
       const { challenge } = credential
       const { request: challengeRequest } = challenge
 
-      // Replay protection
+      // NM-001: Reject vouchers once the channel has been finalized (closed on-chain).
+      if (store) {
+        const finalized = await store.get(`stellar:channel:finalized:${channelAddress}`)
+        if (finalized) {
+          throw new ChannelVerificationError(
+            'Channel has been finalized. No further vouchers accepted.',
+            { channel: channelAddress },
+          )
+        }
+      }
+
+      // Replay protection.
+      // NM-002: The verifyLock serializes calls so the get→put gap cannot
+      // be exploited in a single-process deployment. Multi-process
+      // deployments MUST use a store with atomic put-if-absent semantics.
       if (store) {
         const replayKey = `stellar:challenge:${challenge.id}`
         const existing = await store.get(replayKey)
@@ -183,11 +197,26 @@ export function channel(parameters: channel.Parameters) {
               )
             }
           }
+
+          // NM-003: Reject commitments that exceed the channel's on-chain balance.
+          if (commitmentAmount > state.balance) {
+            throw new ChannelVerificationError(
+              `Commitment ${commitmentAmount} exceeds channel balance ${state.balance}.`,
+              {
+                commitmentAmount: commitmentAmount.toString(),
+                balance: state.balance.toString(),
+              },
+            )
+          }
         } catch (error) {
-          // Re-throw ChannelVerificationError (channel closed)
+          // Re-throw ChannelVerificationError (channel closed / over-balance)
           if (error instanceof ChannelVerificationError) throw error
-          // Silently continue if on-chain check fails (network issue).
-          // The verify logic below still protects against invalid credentials.
+          // NM-005: Fail closed — reject the voucher when the on-chain
+          // check cannot be completed rather than silently skipping it.
+          throw new ChannelVerificationError(
+            'On-chain state check failed. Cannot verify channel status.',
+            { error: error instanceof Error ? error.message : String(error) },
+          )
         }
       }
 

--- a/sdk/src/channel/server/State.ts
+++ b/sdk/src/channel/server/State.ts
@@ -10,6 +10,7 @@ import {
   SOROBAN_RPC_URLS,
   type NetworkId,
 } from '../../constants.js'
+import { scValToBigInt } from '../../scval.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -108,7 +109,7 @@ export async function getChannelState(
       simulateGetter('to'),
     ])
 
-  const balance = scValToI128(balanceVal!)
+  const balance = scValToBigInt(balanceVal!)
   if (!waitingPeriodVal) {
     throw new Error(
       `Failed to simulate refund_waiting_period on channel ${channelAddress}: missing return value`,
@@ -229,11 +230,4 @@ function isEnumVariant(scVal: xdr.ScVal, name: string): boolean {
     // not the shape we expected
   }
   return false
-}
-
-function scValToI128(val: xdr.ScVal): bigint {
-  const i128 = val.i128()
-  const hi = BigInt(i128.hi().toString())
-  const lo = BigInt(i128.lo().toString())
-  return (hi << 64n) | lo
 }

--- a/sdk/src/channel/server/Watcher.test.ts
+++ b/sdk/src/channel/server/Watcher.test.ts
@@ -377,4 +377,46 @@ describe('watchChannel', () => {
 
     stop()
   })
+
+  it('advances cursor when parseEvent throws on a malformed event value', async () => {
+    const errors: Error[] = []
+    const events: unknown[] = []
+
+    // First event has an unexpected ScVal type that scValToBigInt cannot handle;
+    // second event is valid. Cursor must still advance.
+    mockGetEvents
+      .mockResolvedValueOnce({
+        events: [
+          makeEvent({ topicName: 'close', value: xdr.ScVal.scvVoid(), txHash: 'bad-tx' }),
+          makeEvent({ topicName: 'top_up', value: makeI128ScVal(500n), txHash: 'good-tx' }),
+        ],
+        cursor: 'cursor-after-bad',
+      })
+      .mockResolvedValueOnce({
+        events: [],
+        cursor: 'cursor-next',
+      })
+
+    const stop = watchChannel({
+      channel: CHANNEL_ADDRESS,
+      intervalMs: 1000,
+      onEvent: (e) => events.push(e),
+      onError: (e) => errors.push(e),
+    })
+
+    // First poll — bad event skipped, good event delivered, cursor advanced
+    await vi.advanceTimersByTimeAsync(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toMatch(/Cannot convert ScVal/)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ type: 'top_up', amount: 500n })
+
+    // Second poll uses the advanced cursor (not stuck on bad event)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(mockGetEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cursor: 'cursor-after-bad' }),
+    )
+
+    stop()
+  })
 })

--- a/sdk/src/channel/server/Watcher.ts
+++ b/sdk/src/channel/server/Watcher.ts
@@ -99,7 +99,17 @@ export function watchChannel(parameters: watchChannel.Parameters): () => void {
       if (stopped) return
 
       for (const event of response.events) {
-        const parsed = parseEvent(event)
+        let parsed: ChannelEvent | null
+        try {
+          parsed = parseEvent(event)
+        } catch (parseError) {
+          try {
+            onError?.(parseError instanceof Error
+              ? parseError
+              : new Error(String(parseError)))
+          } catch { /* prevent onError from breaking the poll loop */ }
+          continue
+        }
         if (parsed) {
           try {
             onEvent(parsed)

--- a/sdk/src/channel/server/Watcher.ts
+++ b/sdk/src/channel/server/Watcher.ts
@@ -3,6 +3,7 @@ import {
   SOROBAN_RPC_URLS,
   type NetworkId,
 } from '../../constants.js'
+import { scValToBigInt } from '../../scval.js'
 
 // ---------------------------------------------------------------------------
 // Event types
@@ -202,13 +203,13 @@ function parseEvent(event: rpc.Api.EventResponse): ChannelEvent | null {
 
   switch (topicName) {
     case 'close':
-      return { type: 'close', amount: decodeI128(event.value), txHash, ledger, ledgerClosedAt }
+      return { type: 'close', amount: scValToBigInt(event.value), txHash, ledger, ledgerClosedAt }
     case 'close_start':
       return { type: 'close_start', txHash, ledger, ledgerClosedAt }
     case 'refund':
-      return { type: 'refund', amount: decodeI128(event.value), txHash, ledger, ledgerClosedAt }
+      return { type: 'refund', amount: scValToBigInt(event.value), txHash, ledger, ledgerClosedAt }
     case 'top_up':
-      return { type: 'top_up', amount: decodeI128(event.value), txHash, ledger, ledgerClosedAt }
+      return { type: 'top_up', amount: scValToBigInt(event.value), txHash, ledger, ledgerClosedAt }
     default:
       return null
   }
@@ -223,15 +224,4 @@ function decodeSymbol(scVal: xdr.ScVal): string | null {
     // Not a symbol
   }
   return null
-}
-
-function decodeI128(scVal: xdr.ScVal): bigint {
-  try {
-    const i128 = scVal.i128()
-    const hi = BigInt(i128.hi().toString())
-    const lo = BigInt(i128.lo().toString())
-    return (hi << 64n) | lo
-  } catch {
-    return 0n
-  }
 }

--- a/sdk/src/client/Charge.ts
+++ b/sdk/src/client/Charge.ts
@@ -11,6 +11,7 @@ import {
 import { Credential, Method } from 'mppx'
 import { z } from 'zod/mini'
 import {
+  DEFAULT_DECIMALS,
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
@@ -45,6 +46,7 @@ import { fromBaseUnits } from '../Methods.js'
  */
 export function charge(parameters: charge.Parameters) {
   const {
+    decimals = DEFAULT_DECIMALS,
     keypair: keypairParam,
     mode: defaultMode = 'pull',
     onProgress,
@@ -76,7 +78,7 @@ export function charge(parameters: charge.Parameters) {
       onProgress?.({
         type: 'challenge',
         recipient,
-        amount: fromBaseUnits(amount, 7),
+        amount: fromBaseUnits(amount, decimals),
         currency,
         ...(feePayerKey ? { feePayerKey } : {}),
       })
@@ -182,6 +184,8 @@ export declare namespace charge {
     secretKey?: string
     /** Stellar Keypair instance. Provide either this or `secretKey`. */
     keypair?: Keypair
+    /** Number of decimal places for the token. @default 7 */
+    decimals?: number
     /** Custom Soroban RPC URL. Defaults based on network. */
     rpcUrl?: string
     /**

--- a/sdk/src/scval.ts
+++ b/sdk/src/scval.ts
@@ -1,0 +1,43 @@
+import { xdr } from '@stellar/stellar-sdk'
+
+/**
+ * Convert a Soroban ScVal to a BigInt.
+ *
+ * Handles u32, i32, u64, i64, u128, and i128 types. The lo limb is
+ * masked to 64 bits so that unsigned Uint64 values are treated correctly
+ * regardless of the host representation.
+ */
+export function scValToBigInt(val: xdr.ScVal): bigint {
+  const switchValue = val.switch().value
+  // scvU32 = 3
+  if (switchValue === xdr.ScValType.scvU32().value) {
+    return BigInt(val.u32())
+  }
+  // scvI32 = 4
+  if (switchValue === xdr.ScValType.scvI32().value) {
+    return BigInt(val.i32())
+  }
+  // scvU64 = 5
+  if (switchValue === xdr.ScValType.scvU64().value) {
+    return BigInt(val.u64().toString())
+  }
+  // scvI64 = 6
+  if (switchValue === xdr.ScValType.scvI64().value) {
+    return BigInt(val.i64().toString())
+  }
+  // scvU128 = 9
+  if (switchValue === xdr.ScValType.scvU128().value) {
+    const parts = val.u128()
+    const hi = BigInt(parts.hi().toString())
+    const lo = BigInt(parts.lo().toString()) & 0xFFFFFFFFFFFFFFFFn
+    return (hi << 64n) | lo
+  }
+  // scvI128 = 10
+  if (switchValue === xdr.ScValType.scvI128().value) {
+    const parts = val.i128()
+    const hi = BigInt(parts.hi().toString())
+    const lo = BigInt(parts.lo().toString()) & 0xFFFFFFFFFFFFFFFFn
+    return (hi << 64n) | lo
+  }
+  throw new Error(`Cannot convert ScVal type ${switchValue} to BigInt`)
+}

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -16,6 +16,7 @@ import {
 } from '../constants.js'
 import * as Methods from '../Methods.js'
 import { toBaseUnits } from '../Methods.js'
+import { scValToBigInt } from '../scval.js'
 
 export function charge(parameters: charge.Parameters) {
   const {
@@ -133,7 +134,7 @@ export function charge(parameters: charge.Parameters) {
             amount: expectedAmount,
             currency: expectedCurrency,
             recipient: expectedRecipient,
-          })
+          }, networkPassphrase)
 
           // Mark tx hash as used only after successful verification
           if (store) {
@@ -175,9 +176,13 @@ export function charge(parameters: charge.Parameters) {
               typeof feePayer === 'string'
                 ? Keypair.fromSecret(feePayer)
                 : feePayer
+            // NM-004: Cap the fee-bump to prevent a malicious client from
+            // inflating tx.fee and draining the fee payer account.
+            const MAX_FEE_BUMP = 10_000_000 // 1 XLM in stroops
+            const bumpFee = Math.min(Number(tx.fee) * 10, MAX_FEE_BUMP)
             txToSubmit = TransactionBuilder.buildFeeBumpTransaction(
               feePayerKeypair,
-              (Number(tx.fee) * 10).toString(),
+              bumpFee.toString(),
               tx,
               networkPassphrase,
             )
@@ -301,6 +306,7 @@ function verifyFromRawOps(
 function verifySacTransfer(
   txResult: rpc.Api.GetSuccessfulTransactionResponse,
   expected: { amount: bigint; currency: string; recipient: string },
+  networkPassphrase: string,
 ) {
   if (!txResult.envelopeXdr) {
     throw new PaymentVerificationError(
@@ -329,18 +335,11 @@ function verifySacTransfer(
     envelope = txResult.envelopeXdr
   }
 
-  // Determine network passphrase — try testnet first, then mainnet
-  let innerTx: Transaction | null = null
-  for (const np of [NETWORK_PASSPHRASE.testnet, NETWORK_PASSPHRASE.public]) {
-    try {
-      innerTx = new Transaction(envelope, np)
-      break
-    } catch {
-      continue
-    }
-  }
-
-  if (!innerTx) {
+  // NM-009: Use the configured network passphrase instead of guessing.
+  let innerTx: Transaction
+  try {
+    innerTx = new Transaction(envelope, networkPassphrase)
+  } catch {
     throw new PaymentVerificationError(
       'Could not parse transaction envelope for verification.',
       {},
@@ -348,41 +347,6 @@ function verifySacTransfer(
   }
 
   verifyFromRawOps(innerTx, expected)
-}
-
-function scValToBigInt(val: xdr.ScVal): bigint {
-  const switchValue = val.switch().value
-  // scvU32 = 3
-  if (switchValue === xdr.ScValType.scvU32().value) {
-    return BigInt(val.u32())
-  }
-  // scvI32 = 4
-  if (switchValue === xdr.ScValType.scvI32().value) {
-    return BigInt(val.i32())
-  }
-  // scvU64 = 5
-  if (switchValue === xdr.ScValType.scvU64().value) {
-    return BigInt(val.u64().toString())
-  }
-  // scvI64 = 6
-  if (switchValue === xdr.ScValType.scvI64().value) {
-    return BigInt(val.i64().toString())
-  }
-  // scvU128 = 9
-  if (switchValue === xdr.ScValType.scvU128().value) {
-    const parts = val.u128()
-    const hi = BigInt(parts.hi().toString())
-    const lo = BigInt(parts.lo().toString()) & 0xFFFFFFFFFFFFFFFFn
-    return (hi << 64n) | lo
-  }
-  // scvI128 = 10
-  if (switchValue === xdr.ScValType.scvI128().value) {
-    const parts = val.i128()
-    const hi = BigInt(parts.hi().toString())
-    const lo = BigInt(parts.lo().toString()) & 0xFFFFFFFFFFFFFFFFn
-    return (hi << 64n) | lo
-  }
-  throw new Error(`Cannot convert ScVal type ${switchValue} to BigInt`)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix: Address Nemesis Audit Findings (Issue #205)

Fixes all 9 verified findings from the [Nemesis audit](https://github.com/stellar/internal-agents/issues/205) (4 MEDIUM, 5 LOW).

### Changes

| ID | Severity | Fix |
|----|----------|-----|
| NM-001 | **MEDIUM** | Reject vouchers after channel finalization — `store(finalized)` was write-only, now checked at verify entry |
| NM-002 | **MEDIUM** | Document that existing `verifyLock` serialization mitigates the get→put TOCTOU race |
| NM-003 | **MEDIUM** | Reject commitments exceeding on-chain balance when `checkOnChainState` is enabled |
| NM-004 | **MEDIUM** | Cap fee-bump to 1 XLM (10M stroops) to prevent client-controlled fee inflation |
| NM-005 | **LOW** | Fail closed on on-chain check failure instead of silently continuing |
| NM-006 | **LOW** | `toBaseUnits()`/`fromBaseUnits()` now handle negative amounts correctly |
| NM-007 | **LOW** | Client charge progress event uses configurable `decimals` (was hardcoded `7`) |
| NM-008 | **LOW** | Extract shared `scValToBigInt` in `sdk/src/scval.ts` with proper lo-limb masking — replaces 3 inconsistent implementations |
| NM-009 | **LOW** | `verifySacTransfer()` uses configured `networkPassphrase` instead of guessing |

### Files Changed

- `sdk/src/scval.ts` — **new** shared `scValToBigInt` utility
- `sdk/src/server/Charge.ts` — NM-004, NM-008, NM-009
- `sdk/src/channel/server/Channel.ts` — NM-001, NM-002, NM-003, NM-005
- `sdk/src/channel/server/State.ts` — NM-008 (use shared utility)
- `sdk/src/channel/server/Watcher.ts` — NM-008 (use shared utility)
- `sdk/src/Methods.ts` — NM-006
- `sdk/src/client/Charge.ts` — NM-007

### Tests

- 5 new tests: finalization guard, balance check, negative amount handling (3 tests)
- Updated 1 existing test to match NM-005 fail-closed behavior
- **123 tests** across 11 files, all passing
