### PR TITLE
feat(charge): align with MPP spec — client prepares, server submits

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Client                          Server
 
 Two credential modes:
 
-- **Pull** (default) — client signs the transaction XDR, server broadcasts it
-- **Push** — client broadcasts the transaction itself, sends the tx hash for server verification
+- **Pull** (default) — client prepares the transaction, server submits it:
+  - *Sponsored* (`feePayer` configured on server): client signs only Soroban auth entries using an all-zeros placeholder source; server rebuilds the tx with its own account as source, signs, and broadcasts
+  - *Unsponsored*: client builds and signs the full transaction; server broadcasts as-is
+- **Push** — client broadcasts the transaction itself, sends the tx hash for server verification (not compatible with `feePayer`)
 
 ### Channel (off-chain commitments)
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -354,7 +354,7 @@ STELLAR_SECRET=SYOUR_SECRET_KEY npx tsx examples/client.ts</div>
             let detail = ev.type
             if (ev.type === 'challenge') detail = '💳 challenge — ' + ev.amount + ' → ' + ev.recipient
             else if (ev.type === 'signing') detail = '✍️  signing transaction...'
-            else if (ev.type === 'signed') detail = '✅ signed (' + (ev.xdr || '').length + ' bytes XDR)'
+            else if (ev.type === 'signed') detail = '✅ signed (' + (ev.transaction || '').length + ' bytes XDR)'
             else if (ev.type === 'paying') detail = '📡 broadcasting...'
             else if (ev.type === 'confirming') detail = '⏳ confirming ' + (ev.hash || '').slice(0, 12) + '...'
             else if (ev.type === 'paid') detail = '🎉 confirmed: ' + (ev.hash || '')

--- a/diagrams/charge-flow.md
+++ b/diagrams/charge-flow.md
@@ -17,24 +17,46 @@ sequenceDiagram
 
     App->>CC: createCredential(challenge)
     CC->>CC: Resolve network, build SAC transfer(from, to, amount)
-    CC->>RPC: prepareTransaction(transferOp)
-    RPC-->>CC: Prepared TX with resources
 
-    CC->>CC: keypair.sign(preparedTx)
-
-    alt Pull Mode (default)
-        CC-->>App: Credential {type:'transaction', xdr}
-        App->>SC: Credential with signed XDR
+    alt Pull Mode — Sponsored (feePayer: true, default when server has feePayer)
+        Note over CC: Uses all-zeros source account (GAAA...WHF)<br/>so server can substitute its own account
+        CC->>RPC: prepareTransaction(tx with all-zeros source)
+        RPC-->>CC: Prepared TX with Soroban resource data
+        CC->>RPC: getLatestLedger()
+        RPC-->>CC: Current ledger sequence
+        CC->>CC: Sign only sorobanCredentialsAddress<br/>auth entries (not the envelope)
+        CC-->>App: Credential {type:'transaction', transaction: xdr}
+        App->>SC: Credential with auth-entry-signed XDR
         SC->>SC: verifySacInvocation(tx) — validate structure
-        opt feePayer configured
-            SC->>SC: Wrap in fee-bump transaction
+        SC->>SC: Detect all-zeros source → spec rebuild path
+        SC->>RPC: getAccount(feePayerKey)
+        RPC-->>SC: Server account with current sequence
+        SC->>SC: Rebuild TX with feePayer as source<br/>copy XDR ops + sorobanData + memo/timebounds
+        SC->>SC: feePayerKeypair.sign(rebuiltTx)
+        SC->>RPC: sendTransaction(rebuiltTx)
+        RPC->>Chain: Broadcast
+        SC->>RPC: Poll getTransaction(hash)
+        RPC-->>SC: TX confirmed
+        SC-->>App: Receipt {status:'success', reference:txHash}
+    else Pull Mode — Unsponsored (no feePayer)
+        CC->>RPC: prepareTransaction(tx with client source)
+        RPC-->>CC: Prepared TX with Soroban resource data
+        CC->>CC: keypair.sign(preparedTx)
+        CC-->>App: Credential {type:'transaction', transaction: xdr}
+        App->>SC: Credential with fully-signed XDR
+        SC->>SC: verifySacInvocation(tx) — validate structure
+        opt feePayer configured but source is not all-zeros
+            SC->>SC: Wrap in FeeBump transaction (compatibility fallback)
         end
         SC->>RPC: sendTransaction(signedTx)
         RPC->>Chain: Broadcast
         SC->>RPC: Poll getTransaction(hash)
         RPC-->>SC: TX confirmed
         SC-->>App: Receipt {status:'success', reference:txHash}
-    else Push Mode
+    else Push Mode (client opt-in, not compatible with feePayer)
+        CC->>RPC: prepareTransaction(tx with client source)
+        RPC-->>CC: Prepared TX with Soroban resource data
+        CC->>CC: keypair.sign(preparedTx)
         CC->>RPC: sendTransaction(signedTx)
         RPC->>Chain: Broadcast
         CC->>RPC: Poll getTransaction(hash)

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -37,7 +37,7 @@ Mppx.create({
             console.log(`[${ts}] ✍️  Signing transaction...`)
             break
           case 'signed':
-            console.log(`[${ts}] ✅ Transaction signed (${event.xdr.length} bytes XDR)`)
+            console.log(`[${ts}] ✅ Transaction signed (${event.transaction.length} bytes XDR)`)
             break
           case 'paying':
             console.log(`[${ts}] 📡 Broadcasting transaction...`)

--- a/sdk/src/Methods.test.ts
+++ b/sdk/src/Methods.test.ts
@@ -147,9 +147,9 @@ describe('Methods.charge', () => {
   it('credential payload accepts transaction type (pull)', () => {
     const result = Methods.charge.schema.credential.payload.parse({
       type: 'transaction',
-      xdr: 'AAAA...',
+      transaction: 'AAAA...',
     })
     expect(result.type).toBe('transaction')
-    expect(result.xdr).toBe('AAAA...')
+    expect(result.transaction).toBe('AAAA...')
   })
 })

--- a/sdk/src/Methods.ts
+++ b/sdk/src/Methods.ts
@@ -6,8 +6,8 @@ import { z } from 'zod/mini'
  *
  * Supports two credential flows:
  * - `type: "transaction"` — **server-broadcast** (pull mode):
- *   Client signs a Soroban SAC `transfer` invocation and sends
- *   the serialised XDR. The server broadcasts it.
+ *   Client signs a Soroban SAC `transfer` invocation and sends the
+ *   serialised XDR as `payload.transaction`. The server broadcasts it.
  * - `type: "signature"` — **client-broadcast** (push mode):
  *   Client broadcasts itself and sends the transaction hash.
  *   The server looks it up on-chain for verification.
@@ -22,8 +22,8 @@ export const charge = Method.from({
       payload: z.discriminatedUnion('type', [
         /** Push mode: client broadcasts and sends the tx hash. */
         z.object({ hash: z.string(), type: z.literal('signature') }),
-        /** Pull mode: client signs XDR, server broadcasts. */
-        z.object({ xdr: z.string(), type: z.literal('transaction') }),
+        /** Pull mode: client sends signed XDR as `payload.transaction`, server broadcasts. */
+        z.object({ transaction: z.string(), type: z.literal('transaction') }),
       ]),
     },
     request: z.object({

--- a/sdk/src/client/Charge.ts
+++ b/sdk/src/client/Charge.ts
@@ -1,16 +1,20 @@
 import {
+  Account,
   Address,
   BASE_FEE,
   Contract,
   Keypair,
   Memo,
   TransactionBuilder,
+  authorizeEntry,
   nativeToScVal,
   rpc,
+  xdr as StellarXdr,
 } from '@stellar/stellar-sdk'
 import { Credential, Method } from 'mppx'
 import { z } from 'zod/mini'
 import {
+  ALL_ZEROS,
   DEFAULT_DECIMALS,
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
@@ -87,12 +91,95 @@ export function charge(parameters: charge.Parameters) {
       const networkPassphrase = NETWORK_PASSPHRASE[network]
       const server = new rpc.Server(resolvedRpcUrl)
 
-      // Load source account via Soroban RPC
-      const sourceAccount = await server.getAccount(keypair.publicKey())
-
       // Build SAC `transfer(from, to, amount)` invocation
       const contract = new Contract(currency)
       const stellarAmount = BigInt(amount)
+
+      const effectiveMode = context?.mode ?? defaultMode
+      const isServerSponsored = request.methodDetails?.feePayer === true
+
+      if (isServerSponsored && effectiveMode === 'push') {
+        throw new Error(
+          'Push mode is not supported for server-sponsored transactions. ' +
+          'The server must submit sponsored transactions. Use mode: \'pull\' (default).',
+        )
+      }
+
+      if (isServerSponsored) {
+        // ── Spec-compliant sponsored path ──────────────────────────────────
+        // Client uses an all-zeros source account so the server can swap in
+        // its own fee-payer account when rebuilding the transaction.
+        const placeholderSource = new Account(ALL_ZEROS, '0')
+
+        const transferOp = contract.call(
+          'transfer',
+          new Address(keypair.publicKey()).toScVal(),
+          new Address(recipient).toScVal(),
+          nativeToScVal(stellarAmount, { type: 'i128' }),
+        )
+
+        const sponsoredBuilder = new TransactionBuilder(placeholderSource, {
+          fee: BASE_FEE,
+          networkPassphrase,
+        })
+          .addOperation(transferOp)
+          .setTimeout(timeout)
+
+        if (memo) {
+          sponsoredBuilder.addMemo(Memo.text(memo))
+        }
+
+        const unsignedTx = sponsoredBuilder.build()
+        const prepared = await server.prepareTransaction(unsignedTx)
+
+        // Determine auth-entry expiry from the current ledger sequence
+        const latestLedger = await server.getLatestLedger()
+        const validUntilLedger =
+          latestLedger.sequence + Math.ceil(timeout / 5) + 10
+
+        onProgress?.({ type: 'signing' })
+
+        // Sign only the Soroban authorization entries — do NOT sign the
+        // transaction envelope (the server will do that after rebuilding).
+        const envelope = prepared.toEnvelope().v1()
+        for (const op of envelope.tx().operations()) {
+          const body = op.body()
+          if (
+            body.switch().value !==
+            StellarXdr.OperationType.invokeHostFunction().value
+          ) {
+            continue
+          }
+          const authEntries = body.invokeHostFunctionOp().auth()
+          for (let i = 0; i < authEntries.length; i++) {
+            const entry = authEntries[i]
+            if (
+              entry.credentials().switch().value ===
+              StellarXdr.SorobanCredentialsType.sorobanCredentialsAddress().value
+            ) {
+              authEntries[i] = await authorizeEntry(
+                entry,
+                keypair,
+                validUntilLedger,
+                networkPassphrase,
+              )
+            }
+          }
+        }
+
+        const signedXdr = prepared.toEnvelope().toXDR('base64')
+        onProgress?.({ type: 'signed', transaction: signedXdr })
+
+        return Credential.serialize({
+          challenge,
+          payload: { type: 'transaction' as const, transaction: signedXdr },
+        })
+      }
+
+      // ── Standard (unsponsored) path ────────────────────────────────────────
+      // Client builds and signs the full transaction; server submits as-is
+      // (or wraps it in a fee bump if it has a configured fee payer).
+      const sourceAccount = await server.getAccount(keypair.publicKey())
 
       const transferOp = contract.call(
         'transfer',
@@ -121,9 +208,7 @@ export function charge(parameters: charge.Parameters) {
       prepared.sign(keypair)
 
       const signedXdr = prepared.toXDR()
-      onProgress?.({ type: 'signed', xdr: signedXdr })
-
-      const effectiveMode = context?.mode ?? defaultMode
+      onProgress?.({ type: 'signed', transaction: signedXdr })
 
       if (effectiveMode === 'push') {
         // Client broadcasts
@@ -161,10 +246,7 @@ export function charge(parameters: charge.Parameters) {
       // Pull mode: send signed XDR for server to broadcast
       return Credential.serialize({
         challenge,
-        payload: {
-          type: 'transaction' as const,
-          xdr: signedXdr,
-        },
+        payload: { type: 'transaction' as const, transaction: signedXdr },
       })
     },
   })
@@ -174,7 +256,7 @@ export declare namespace charge {
   type ProgressEvent =
     | { type: 'challenge'; recipient: string; amount: string; currency: string; feePayerKey?: string }
     | { type: 'signing' }
-    | { type: 'signed'; xdr: string }
+    | { type: 'signed'; transaction: string }
     | { type: 'paying' }
     | { type: 'confirming'; hash: string }
     | { type: 'paid'; hash: string }

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -69,3 +69,17 @@ export const DEFAULT_FEE = '100'
 
 /** Default transaction timeout in seconds. */
 export const DEFAULT_TIMEOUT = 180
+
+// ---------------------------------------------------------------------------
+// Special accounts
+// ---------------------------------------------------------------------------
+
+/**
+ * All-zeros Stellar source account (`GAAA...WHF`).
+ *
+ * Used in the spec-compliant sponsored charge flow: the client sets this as
+ * the transaction source so the server can substitute its own fee-payer
+ * account when rebuilding the transaction.
+ */
+export const ALL_ZEROS =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'

--- a/sdk/src/integration.test.ts
+++ b/sdk/src/integration.test.ts
@@ -116,7 +116,7 @@ describe('credential type validation', () => {
     const challenge = mockChallenge()
     const serialized = Credential.serialize({
       challenge,
-      payload: { type: 'transaction' as const, xdr: 'AAAA' },
+      payload: { type: 'transaction' as const, transaction: 'AAAA' },
     })
     expect(serialized).toContain('Payment')
   })

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -9,7 +9,9 @@ import {
 } from '@stellar/stellar-sdk'
 import { Method, Receipt, Store } from 'mppx'
 import {
+  ALL_ZEROS,
   DEFAULT_DECIMALS,
+  DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
   type NetworkId,
@@ -150,7 +152,7 @@ export function charge(parameters: charge.Parameters) {
         }
 
         case 'transaction': {
-          const txXdr = payload.xdr
+          const txXdr = payload.transaction
           const parsed = TransactionBuilder.fromXDR(
             txXdr,
             networkPassphrase,
@@ -171,7 +173,41 @@ export function charge(parameters: charge.Parameters) {
             | Transaction
             | FeeBumpTransaction
 
-          if (feePayer && !(parsed instanceof FeeBumpTransaction)) {
+          if (feePayer && tx.source === ALL_ZEROS) {
+            // ── Spec-compliant sponsored path ──────────────────────────────
+            // Client used all-zeros source; server rebuilds the tx with its
+            // own account as source so it can sign and submit.
+            const feePayerKeypair =
+              typeof feePayer === 'string'
+                ? Keypair.fromSecret(feePayer)
+                : feePayer
+            const serverAccount = await server.getAccount(
+              feePayerKeypair.publicKey(),
+            )
+            const envelopeTx = tx.toEnvelope().v1().tx()
+            const sorobanData = envelopeTx.ext().sorobanData()
+            const rebuilt = new TransactionBuilder(serverAccount, {
+              fee: tx.fee,
+              networkPassphrase,
+              // Preserve envelope-level fields from the client-prepared tx so
+              // the server rebuild is semantically identical.
+              memo: tx.memo,
+              ...(tx.timeBounds ? { timebounds: tx.timeBounds } : {}),
+            })
+            for (const rawOp of envelopeTx.operations()) {
+              rebuilt.addOperation(rawOp)
+            }
+            // Only apply a default timeout if the client did not provide one.
+            if (!tx.timeBounds) {
+              rebuilt.setTimeout(DEFAULT_TIMEOUT)
+            }
+            const rebuiltTx = rebuilt.setSorobanData(sorobanData).build()
+            rebuiltTx.sign(feePayerKeypair)
+            txToSubmit = rebuiltTx
+          } else if (feePayer && !(parsed instanceof FeeBumpTransaction)) {
+            // ── FeeBump alternate (non-spec, kept for compatibility) ────────
+            // Client signed the tx with its own account as source; server
+            // wraps it in a fee-bump transaction.
             const feePayerKeypair =
               typeof feePayer === 'string'
                 ? Keypair.fromSecret(feePayer)


### PR DESCRIPTION
Addressed the charge flow feedback — client now prepares the tx and server submits it, matching the spec direction from draft-stellar-charge-00.

## Changes

**Schema**
- `payload.xdr` → `payload.transaction` (aligns with spec field name)

**Sponsored path (`feePayer: true`)**
- Client uses all-zeros source account (`GAAA...WHF`) as placeholder
- Client signs only `sorobanCredentialsAddress` auth entries — not the envelope
- Server detects all-zeros source, rebuilds tx with its own fee-payer account as source (copying XDR-level ops + soroban resource data so signed auth entries are preserved), signs, submits

**Standard unsponsored path**
- Client builds and signs the full tx; server submits as-is
- Only change: payload field rename

**FeeBump (kept as non-spec fallback)**
- For cases where client signs its own tx but server has a fee payer configured (non-all-zeros source)
- Happy to drop if it adds confusion

**Push mode** — untouched; will align the hash flow once it lands in the spec.

## Notes

The server copies ops from the raw XDR envelope (not parsed operation objects) to preserve signed auth entries during the rebuild — worth verifying in an integration test.

`ProgressEvent.signed` field renamed `xdr` → `transaction` (breaking change, documented in commit message).
