### PR TITLE
fix: align charge module with draft-stellar-charge-00 spec

### DIFF
--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -58,6 +58,9 @@ import { getChannelState, type ChannelState } from './State.js'
  * })
  * ```
  */
+const LOG_PREFIX = '[stellar:channel]'
+const STORE_PREFIX = 'stellar:channel'
+
 export function channel(parameters: channel.Parameters) {
   const {
     channel: channelAddress,
@@ -95,7 +98,7 @@ export function channel(parameters: channel.Parameters) {
   const feeBumpKeypair = feeBumpSignerParam ? resolveKeypair(feeBumpSignerParam) : undefined
 
   // Track cumulative amounts per channel in the store
-  const cumulativeKey = `stellar:channel:cumulative:${channelAddress}`
+  const cumulativeKey = `${STORE_PREFIX}:cumulative:${channelAddress}`
 
   // Serialize verify operations to prevent concurrent double-acceptance.
   // Without a transactional store, two concurrent verify calls could both
@@ -149,13 +152,13 @@ export function channel(parameters: channel.Parameters) {
     // NM-001: Reject credentials once the channel has been closed on-chain.
     // Applied to all actions including 'open'.
     if (store) {
-      const closed = await store.get(`stellar:channel:closed:${channelAddress}`)
+      const closed = await store.get(`${STORE_PREFIX}:closed:${channelAddress}`)
       if (closed) {
-        logger.warn('[stellar:channel] Rejecting credential — channel already closed', {
+        logger.warn(`${LOG_PREFIX} Rejecting credential — channel already closed`, {
           channel: channelAddress,
         })
         throw new ChannelVerificationError(
-          '[stellar:channel] Channel has been closed. No further credentials accepted.',
+          `${LOG_PREFIX} Channel has been closed. No further credentials accepted.`,
           { channel: channelAddress },
         )
       }
@@ -166,7 +169,7 @@ export function channel(parameters: channel.Parameters) {
     // be exploited in a single-process deployment. Multi-process
     // deployments MUST use a store with atomic put-if-absent semantics.
     if (store) {
-      const replayKey = `stellar:channel:challenge:${challenge.id}`
+      const replayKey = `${STORE_PREFIX}:challenge:${challenge.id}`
       const existing = await store.get(replayKey)
       if (existing) {
         throw new ChannelVerificationError('Challenge already used. Replay rejected.', {
@@ -210,14 +213,14 @@ export function channel(parameters: channel.Parameters) {
           sourceAccount,
         })
 
-        logger.debug('[stellar:channel] On-chain state check', {
+        logger.debug(`${LOG_PREFIX} On-chain state check`, {
           balance: state.balance.toString(),
           closeAt: state.closeEffectiveAtLedger,
         })
 
         // Cache the on-chain state for the caller
         if (store) {
-          await store.put(`stellar:channel:state:${channelAddress}`, {
+          await store.put(`${STORE_PREFIX}:state:${channelAddress}`, {
             balance: state.balance.toString(),
             closeEffectiveAtLedger: state.closeEffectiveAtLedger,
             currentLedger: state.currentLedger,
@@ -229,12 +232,12 @@ export function channel(parameters: channel.Parameters) {
           onDisputeDetected?.(state)
 
           if (state.currentLedger >= state.closeEffectiveAtLedger) {
-            logger.warn('[stellar:channel] Channel is closed — effective ledger reached', {
+            logger.warn(`${LOG_PREFIX} Channel is closed — effective ledger reached`, {
               closeEffectiveAtLedger: state.closeEffectiveAtLedger,
               currentLedger: state.currentLedger,
             })
             throw new ChannelVerificationError(
-              '[stellar:channel] Channel is closed: close effective ledger has been reached.',
+              `${LOG_PREFIX} Channel is closed: close effective ledger has been reached.`,
               {
                 closeEffectiveAtLedger: String(state.closeEffectiveAtLedger),
                 currentLedger: String(state.currentLedger),
@@ -245,12 +248,12 @@ export function channel(parameters: channel.Parameters) {
 
         // NM-003: Reject commitments that exceed the channel's on-chain balance.
         if (commitmentAmount > state.balance) {
-          logger.warn('[stellar:channel] Commitment exceeds channel balance', {
+          logger.warn(`${LOG_PREFIX} Commitment exceeds channel balance`, {
             commitmentAmount: commitmentAmount.toString(),
             balance: state.balance.toString(),
           })
           throw new ChannelVerificationError(
-            `[stellar:channel] Commitment ${commitmentAmount} exceeds channel balance ${state.balance}.`,
+            `${LOG_PREFIX} Commitment ${commitmentAmount} exceeds channel balance ${state.balance}.`,
             {
               commitmentAmount: commitmentAmount.toString(),
               balance: state.balance.toString(),
@@ -262,11 +265,11 @@ export function channel(parameters: channel.Parameters) {
         if (error instanceof ChannelVerificationError) throw error
         // NM-005: Fail closed — reject the voucher when the on-chain
         // check cannot be completed rather than silently skipping it.
-        logger.warn('[stellar:channel] On-chain state check failed', {
+        logger.warn(`${LOG_PREFIX} On-chain state check failed`, {
           error: error instanceof Error ? error.message : String(error),
         })
         throw new ChannelVerificationError(
-          '[stellar:channel] On-chain state check failed. Cannot verify channel status.',
+          `${LOG_PREFIX} On-chain state check failed. Cannot verify channel status.`,
           { error: error instanceof Error ? error.message : String(error) },
         )
       }
@@ -276,12 +279,12 @@ export function channel(parameters: channel.Parameters) {
     try {
       validateHexSignature(signatureHex)
     } catch (err) {
-      logger.warn('[stellar:channel] Invalid signature format', {
+      logger.warn(`${LOG_PREFIX} Invalid signature format`, {
         signature: signatureHex,
         length: signatureHex?.length,
       })
       throw new ChannelVerificationError(
-        `[stellar:channel] ${err instanceof Error ? err.message : 'Invalid signature'}`,
+        `${LOG_PREFIX} ${err instanceof Error ? err.message : 'Invalid signature'}`,
         { signature: signatureHex, length: String(signatureHex?.length ?? 0) },
       )
     }
@@ -300,22 +303,22 @@ export function channel(parameters: channel.Parameters) {
     validateAmount(challengeRequest.amount)
     const requestedAmount = BigInt(challengeRequest.amount)
     if (requestedAmount <= 0n) {
-      logger.warn('[stellar:channel] Non-positive requested amount', {
+      logger.warn(`${LOG_PREFIX} Non-positive requested amount`, {
         requestedAmount: requestedAmount.toString(),
       })
-      throw new ChannelVerificationError('[stellar:channel] Requested amount must be positive.', {
+      throw new ChannelVerificationError(`${LOG_PREFIX} Requested amount must be positive.`, {
         requestedAmount: requestedAmount.toString(),
       })
     }
 
     // The new cumulative must be strictly greater than previous cumulative
     if (commitmentAmount <= previousCumulative) {
-      logger.warn('[stellar:channel] Commitment not greater than previous cumulative', {
+      logger.warn(`${LOG_PREFIX} Commitment not greater than previous cumulative`, {
         commitmentAmount: commitmentAmount.toString(),
         previousCumulative: previousCumulative.toString(),
       })
       throw new ChannelVerificationError(
-        `[stellar:channel] Commitment amount ${commitmentAmount} must be greater than previous cumulative ${previousCumulative}.`,
+        `${LOG_PREFIX} Commitment amount ${commitmentAmount} must be greater than previous cumulative ${previousCumulative}.`,
         {
           commitmentAmount: commitmentAmount.toString(),
           previousCumulative: previousCumulative.toString(),
@@ -325,13 +328,13 @@ export function channel(parameters: channel.Parameters) {
 
     // The commitment must cover the requested amount
     if (commitmentAmount < previousCumulative + requestedAmount) {
-      logger.warn('[stellar:channel] Commitment does not cover requested amount', {
+      logger.warn(`${LOG_PREFIX} Commitment does not cover requested amount`, {
         commitmentAmount: commitmentAmount.toString(),
         requestedAmount: requestedAmount.toString(),
         previousCumulative: previousCumulative.toString(),
       })
       throw new ChannelVerificationError(
-        `[stellar:channel] Commitment amount ${commitmentAmount} does not cover the requested amount ${requestedAmount} (previous cumulative: ${previousCumulative}).`,
+        `${LOG_PREFIX} Commitment amount ${commitmentAmount} does not cover the requested amount ${requestedAmount} (previous cumulative: ${previousCumulative}).`,
         {
           commitmentAmount: commitmentAmount.toString(),
           requestedAmount: requestedAmount.toString(),
@@ -343,7 +346,7 @@ export function channel(parameters: channel.Parameters) {
     // Verify: call prepare_commitment on the channel contract to
     // reconstruct the expected commitment bytes, then verify the
     // ed25519 signature.
-    logger.debug('[stellar:channel] Verifying commitment signature...')
+    logger.debug(`${LOG_PREFIX} Verifying commitment signature...`)
     const contract = new Contract(channelAddress)
     const call = contract.call(
       'prepare_commitment',
@@ -363,10 +366,7 @@ export function channel(parameters: channel.Parameters) {
 
     const returnValue = simResult.result?.retval
     if (!returnValue) {
-      throw new ChannelVerificationError(
-        '[stellar:channel] prepare_commitment returned no value.',
-        {},
-      )
+      throw new ChannelVerificationError(`${LOG_PREFIX} prepare_commitment returned no value.`, {})
     }
 
     const commitmentBytes = returnValue.bytes()
@@ -375,12 +375,12 @@ export function channel(parameters: channel.Parameters) {
     const valid = commitmentKeypair.verify(Buffer.from(commitmentBytes), signatureBytes)
 
     if (!valid) {
-      logger.warn('[stellar:channel] Commitment signature verification failed', {
+      logger.warn(`${LOG_PREFIX} Commitment signature verification failed`, {
         amount: commitmentAmount.toString(),
         channel: channelAddress,
       })
       throw new ChannelVerificationError(
-        '[stellar:channel] Commitment signature verification failed.',
+        `${LOG_PREFIX} Commitment signature verification failed.`,
         {
           amount: commitmentAmount.toString(),
           channel: channelAddress,
@@ -399,7 +399,7 @@ export function channel(parameters: channel.Parameters) {
     if (action === 'close') {
       if (!signerKeypair) {
         throw new ChannelVerificationError(
-          '[stellar:channel] Close action requires a signer to be configured.',
+          `${LOG_PREFIX} Close action requires a signer to be configured.`,
           {},
         )
       }
@@ -431,7 +431,7 @@ export function channel(parameters: channel.Parameters) {
         })
       }
 
-      logger.debug('[stellar:channel] Broadcasting close tx...')
+      logger.debug(`${LOG_PREFIX} Broadcasting close tx...`)
       const sendResult = await server.sendTransaction(txToSubmit)
 
       const txResult = await pollTransaction(server, sendResult.hash, {
@@ -442,7 +442,7 @@ export function channel(parameters: channel.Parameters) {
 
       if (txResult.status !== 'SUCCESS') {
         throw new ChannelVerificationError(
-          `[stellar:channel] Close transaction failed: ${txResult.status}`,
+          `${LOG_PREFIX} Close transaction failed: ${txResult.status}`,
           {
             hash: sendResult.hash,
             status: txResult.status,
@@ -451,9 +451,9 @@ export function channel(parameters: channel.Parameters) {
       }
 
       // Mark channel as closed in store
-      logger.debug('[stellar:channel] Channel closed, marking in store')
+      logger.debug(`${LOG_PREFIX} Channel closed, marking in store`)
       if (store) {
-        await store.put(`stellar:channel:closed:${channelAddress}`, {
+        await store.put(`${STORE_PREFIX}:closed:${channelAddress}`, {
           closedAt: new Date().toISOString(),
           txHash: sendResult.hash,
           amount: commitmentAmount.toString(),
@@ -489,7 +489,7 @@ export function channel(parameters: channel.Parameters) {
 
     if (!txXdr || typeof txXdr !== 'string') {
       throw new ChannelVerificationError(
-        '[stellar:channel] Open action requires a signed transaction XDR.',
+        `${LOG_PREFIX} Open action requires a signed transaction XDR.`,
         {},
       )
     }
@@ -498,11 +498,11 @@ export function channel(parameters: channel.Parameters) {
     try {
       validateHexSignature(signatureHex)
     } catch {
-      logger.warn('[stellar:channel] Invalid commitment signature for open action', {
+      logger.warn(`${LOG_PREFIX} Invalid commitment signature for open action`, {
         length: signatureHex?.length,
       })
       throw new ChannelVerificationError(
-        '[stellar:channel] Invalid commitment signature for open action.',
+        `${LOG_PREFIX} Invalid commitment signature for open action.`,
         {
           length: String(signatureHex?.length ?? 0),
         },
@@ -519,7 +519,7 @@ export function channel(parameters: channel.Parameters) {
     const requestedAmount = BigInt(challenge.request.amount)
     if (requestedAmount <= 0n) {
       throw new ChannelVerificationError(
-        '[stellar:channel] Open action requires a positive requested amount.',
+        `${LOG_PREFIX} Open action requires a positive requested amount.`,
         {
           requestedAmount: requestedAmount.toString(),
         },
@@ -527,7 +527,7 @@ export function channel(parameters: channel.Parameters) {
     }
     if (commitmentAmount <= 0n) {
       throw new ChannelVerificationError(
-        '[stellar:channel] Open action requires a positive commitment amount.',
+        `${LOG_PREFIX} Open action requires a positive commitment amount.`,
         {
           commitmentAmount: commitmentAmount.toString(),
         },
@@ -535,7 +535,7 @@ export function channel(parameters: channel.Parameters) {
     }
     if (commitmentAmount < requestedAmount) {
       throw new ChannelVerificationError(
-        '[stellar:channel] Commitment amount does not cover requested amount for open action.',
+        `${LOG_PREFIX} Commitment amount does not cover requested amount for open action.`,
         {
           commitmentAmount: commitmentAmount.toString(),
           requestedAmount: requestedAmount.toString(),
@@ -548,14 +548,14 @@ export function channel(parameters: channel.Parameters) {
       const existing = await store.get(cumulativeKey)
       if (existing) {
         throw new ChannelVerificationError(
-          '[stellar:channel] Channel is already open. Cannot replay an open credential.',
+          `${LOG_PREFIX} Channel is already open. Cannot replay an open credential.`,
           { channel: channelAddress },
         )
       }
     }
 
     // Verify the initial commitment signature via prepare_commitment simulation
-    logger.debug('[stellar:channel] Verifying commitment signature...')
+    logger.debug(`${LOG_PREFIX} Verifying commitment signature...`)
     const contract = new Contract(channelAddress)
     const call = contract.call(
       'prepare_commitment',
@@ -576,7 +576,7 @@ export function channel(parameters: channel.Parameters) {
     const returnValue = simResult.result?.retval
     if (!returnValue) {
       throw new ChannelVerificationError(
-        '[stellar:channel] prepare_commitment returned no value during open.',
+        `${LOG_PREFIX} prepare_commitment returned no value during open.`,
         {},
       )
     }
@@ -586,12 +586,12 @@ export function channel(parameters: channel.Parameters) {
     const valid = commitmentKeypair.verify(Buffer.from(commitmentBytes), signatureBytes)
 
     if (!valid) {
-      logger.warn('[stellar:channel] Initial commitment signature verification failed', {
+      logger.warn(`${LOG_PREFIX} Initial commitment signature verification failed`, {
         amount: commitmentAmount.toString(),
         channel: channelAddress,
       })
       throw new ChannelVerificationError(
-        '[stellar:channel] Initial commitment signature verification failed.',
+        `${LOG_PREFIX} Initial commitment signature verification failed.`,
         {
           amount: commitmentAmount.toString(),
           channel: channelAddress,
@@ -604,7 +604,7 @@ export function channel(parameters: channel.Parameters) {
     try {
       openTx = TransactionBuilder.fromXDR(txXdr, networkPassphrase)
     } catch (err) {
-      throw new ChannelVerificationError('[stellar:channel] Invalid open transaction XDR.', {
+      throw new ChannelVerificationError(`${LOG_PREFIX} Invalid open transaction XDR.`, {
         error: err instanceof Error ? err.message : String(err),
       })
     }
@@ -628,7 +628,7 @@ export function channel(parameters: channel.Parameters) {
 
     if (txResult.status !== 'SUCCESS') {
       throw new ChannelVerificationError(
-        `[stellar:channel] Open transaction failed: ${txResult.status}`,
+        `${LOG_PREFIX} Open transaction failed: ${txResult.status}`,
         {
           hash: sendResult.hash,
           status: txResult.status,
@@ -730,7 +730,7 @@ export async function close(parameters: {
     })
   }
 
-  log.debug('[stellar:channel] Broadcasting close tx...')
+  log.debug(`${LOG_PREFIX} Broadcasting close tx...`)
   const result = await server.sendTransaction(txToSubmit)
 
   const txResult = await pollTransaction(server, result.hash, {
@@ -741,7 +741,7 @@ export async function close(parameters: {
 
   if (txResult.status !== 'SUCCESS') {
     throw new ChannelVerificationError(
-      `[stellar:channel] Close transaction failed: ${txResult.status}`,
+      `${LOG_PREFIX} Close transaction failed: ${txResult.status}`,
       {
         hash: result.hash,
         status: txResult.status,

--- a/sdk/src/charge/Methods.test.ts
+++ b/sdk/src/charge/Methods.test.ts
@@ -96,30 +96,31 @@ describe('Methods.charge', () => {
     expect(result.externalId).toBe('order-123')
   })
 
-  it('request schema accepts methodDetails with reference', () => {
+  it('request schema accepts methodDetails with network and feePayer', () => {
     const result = Methods.charge.schema.request.parse({
       amount: '100000',
       currency: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
       recipient: 'GBXYZ',
       methodDetails: {
-        reference: 'abc-123',
-        network: 'testnet',
-      },
-    })
-    expect(result.methodDetails?.reference).toBe('abc-123')
-    expect(result.methodDetails?.network).toBe('testnet')
-  })
-
-  it('request schema accepts methodDetails with feePayer', () => {
-    const result = Methods.charge.schema.request.parse({
-      amount: '100000',
-      currency: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
-      recipient: 'GBXYZ',
-      methodDetails: {
+        network: 'stellar:testnet',
         feePayer: true,
       },
     })
+    expect(result.methodDetails?.network).toBe('stellar:testnet')
     expect(result.methodDetails?.feePayer).toBe(true)
+  })
+
+  it('request schema accepts methodDetails with network only', () => {
+    const result = Methods.charge.schema.request.parse({
+      amount: '100000',
+      currency: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      recipient: 'GBXYZ',
+      methodDetails: {
+        network: 'stellar:pubnet',
+      },
+    })
+    expect(result.methodDetails?.network).toBe('stellar:pubnet')
+    expect(result.methodDetails?.feePayer).toBeUndefined()
   })
 
   it('request schema allows omitting methodDetails', () => {
@@ -137,7 +138,9 @@ describe('Methods.charge', () => {
       hash: 'abc123',
     })
     expect(result.type).toBe('hash')
-    expect(result.hash).toBe('abc123')
+    if (result.type === 'hash') {
+      expect(result.hash).toBe('abc123')
+    }
   })
 
   it('credential payload accepts transaction type (pull)', () => {
@@ -146,6 +149,8 @@ describe('Methods.charge', () => {
       transaction: 'AAAA...',
     })
     expect(result.type).toBe('transaction')
-    expect(result.transaction).toBe('AAAA...')
+    if (result.type === 'transaction') {
+      expect(result.transaction).toBe('AAAA...')
+    }
   })
 })

--- a/sdk/src/charge/Methods.ts
+++ b/sdk/src/charge/Methods.ts
@@ -37,15 +37,11 @@ export const charge = Method.from({
       description: z.optional(z.string()),
       /** Merchant-provided reconciliation ID (e.g. order ID, invoice number). */
       externalId: z.optional(z.string()),
-      /** Method-specific details injected by the server. */
+      /** Method-specific details injected by the server via request(). */
       methodDetails: z.optional(
         z.object({
-          /** Server-generated unique tracking ID. */
-          reference: z.optional(z.string()),
-          /** Stellar network identifier ("public" | "testnet"). */
-          network: z.optional(z.string()),
-          /** Optional memo text to attach to the transaction. */
-          memo: z.optional(z.string()),
+          /** CAIP-2 network identifier (e.g. "stellar:testnet", "stellar:pubnet"). */
+          network: z.string(),
           /** Whether the server will sponsor transaction fees. */
           feePayer: z.optional(z.boolean()),
         }),

--- a/sdk/src/charge/client/Charge.test.ts
+++ b/sdk/src/charge/client/Charge.test.ts
@@ -1,6 +1,7 @@
 import { Keypair } from '@stellar/stellar-sdk'
 import { describe, expect, it } from 'vitest'
 import { charge } from './Charge.js'
+import { CAIP2_TO_NETWORK } from '../../constants.js'
 
 const TEST_KEYPAIR = Keypair.random()
 
@@ -54,5 +55,43 @@ describe('stellar client charge', () => {
   it('accepts push mode', () => {
     const method = charge({ keypair: TEST_KEYPAIR, mode: 'push' })
     expect(method.name).toBe('stellar')
+  })
+
+  it('throws when neither keypair nor secretKey is provided', () => {
+    expect(() => charge({} as any)).toThrow('Either keypair or secretKey must be provided')
+  })
+})
+
+describe('CAIP-2 network mapping', () => {
+  it('maps stellar:testnet to testnet', () => {
+    expect(CAIP2_TO_NETWORK['stellar:testnet']).toBe('testnet')
+  })
+
+  it('maps stellar:pubnet to public', () => {
+    expect(CAIP2_TO_NETWORK['stellar:pubnet']).toBe('public')
+  })
+
+  it('returns undefined for unknown CAIP-2 identifiers', () => {
+    expect(CAIP2_TO_NETWORK['stellar:unknown']).toBeUndefined()
+  })
+})
+
+describe('DID-PKH format', () => {
+  it('constructs correct DID-PKH from CAIP-2 network and public key', () => {
+    const kp = Keypair.random()
+    const caip2Network = 'stellar:testnet'
+    const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
+    const source = `did:pkh:stellar:${caip2Component}:${kp.publicKey()}`
+
+    expect(source).toMatch(/^did:pkh:stellar:testnet:G[A-Z0-9]{55}$/)
+  })
+
+  it('uses pubnet component for mainnet', () => {
+    const kp = Keypair.random()
+    const caip2Network = 'stellar:pubnet'
+    const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
+    const source = `did:pkh:stellar:${caip2Component}:${kp.publicKey()}`
+
+    expect(source).toMatch(/^did:pkh:stellar:pubnet:G[A-Z0-9]{55}$/)
   })
 })

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -115,7 +115,6 @@ export function charge(parameters: charge.Parameters) {
         )
       }
 
-      // Gap #4: Derive ledger expiration from challenge.expires instead of timeout
       const expiresTimestamp: number | undefined = challenge.expires
         ? Math.floor(new Date(challenge.expires).getTime() / 1000)
         : undefined
@@ -138,7 +137,6 @@ export function charge(parameters: charge.Parameters) {
           networkPassphrase,
         }).addOperation(transferOp)
 
-        // Gap #5: Set timeBounds.maxTime to expires timestamp
         if (expiresTimestamp) {
           sponsoredBuilder.setTimebounds(0, expiresTimestamp)
         } else {
@@ -148,7 +146,6 @@ export function charge(parameters: charge.Parameters) {
         const unsignedTx = sponsoredBuilder.build()
         const prepared = await server.prepareTransaction(unsignedTx)
 
-        // Gap #4: Derive auth-entry expiry from challenge.expires
         const latestLedger = await server.getLatestLedger()
         let validUntilLedger: number
         if (expiresTimestamp) {
@@ -190,7 +187,6 @@ export function charge(parameters: charge.Parameters) {
         const signedXdr = prepared.toEnvelope().toXDR('base64')
         onProgress?.({ type: 'signed', transaction: signedXdr })
 
-        // Gap #14: Add DID-PKH source field (derived from resolved network for consistency)
         const didComponent = network === 'public' ? 'pubnet' : network
         const source = `did:pkh:stellar:${didComponent}:${keypair.publicKey()}`
 
@@ -218,7 +214,6 @@ export function charge(parameters: charge.Parameters) {
         networkPassphrase,
       }).addOperation(transferOp)
 
-      // Gap #5: Set timeBounds.maxTime to expires timestamp for unsponsored path
       if (expiresTimestamp) {
         builder.setTimebounds(0, expiresTimestamp)
       } else {
@@ -236,7 +231,6 @@ export function charge(parameters: charge.Parameters) {
       const signedXdr = prepared.toXDR()
       onProgress?.({ type: 'signed', transaction: signedXdr })
 
-      // Gap #14: Add DID-PKH source field (derived from resolved network for consistency)
       const didComponent = network === 'public' ? 'pubnet' : network
       const source = `did:pkh:stellar:${didComponent}:${keypair.publicKey()}`
 

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -140,11 +140,7 @@ export function charge(parameters: charge.Parameters) {
 
         // Gap #5: Set timeBounds.maxTime to expires timestamp
         if (expiresTimestamp) {
-          sponsoredBuilder.setTimeout(0)
-          ;(sponsoredBuilder as any).timeBounds = {
-            minTime: 0,
-            maxTime: expiresTimestamp,
-          }
+          sponsoredBuilder.setTimebounds(0, expiresTimestamp)
         } else {
           sponsoredBuilder.setTimeout(timeout)
         }
@@ -194,9 +190,9 @@ export function charge(parameters: charge.Parameters) {
         const signedXdr = prepared.toEnvelope().toXDR('base64')
         onProgress?.({ type: 'signed', transaction: signedXdr })
 
-        // Gap #14: Add DID-PKH source field
-        const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
-        const source = `did:pkh:stellar:${caip2Component}:${keypair.publicKey()}`
+        // Gap #14: Add DID-PKH source field (derived from resolved network for consistency)
+        const didComponent = network === 'public' ? 'pubnet' : network
+        const source = `did:pkh:stellar:${didComponent}:${keypair.publicKey()}`
 
         return Credential.serialize({
           challenge,
@@ -224,11 +220,7 @@ export function charge(parameters: charge.Parameters) {
 
       // Gap #5: Set timeBounds.maxTime to expires timestamp for unsponsored path
       if (expiresTimestamp) {
-        builder.setTimeout(0)
-        ;(builder as any).timeBounds = {
-          minTime: 0,
-          maxTime: expiresTimestamp,
-        }
+        builder.setTimebounds(0, expiresTimestamp)
       } else {
         builder.setTimeout(timeout)
       }
@@ -244,9 +236,9 @@ export function charge(parameters: charge.Parameters) {
       const signedXdr = prepared.toXDR()
       onProgress?.({ type: 'signed', transaction: signedXdr })
 
-      // Gap #14: Add DID-PKH source field
-      const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
-      const source = `did:pkh:stellar:${caip2Component}:${keypair.publicKey()}`
+      // Gap #14: Add DID-PKH source field (derived from resolved network for consistency)
+      const didComponent = network === 'public' ? 'pubnet' : network
+      const source = `did:pkh:stellar:${didComponent}:${keypair.publicKey()}`
 
       if (effectiveMode === 'push') {
         // Client broadcasts

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -200,7 +200,8 @@ export function charge(parameters: charge.Parameters) {
 
         return Credential.serialize({
           challenge,
-          payload: { type: 'transaction' as const, transaction: signedXdr, source },
+          payload: { type: 'transaction' as const, transaction: signedXdr },
+          source,
         })
       }
 
@@ -264,14 +265,16 @@ export function charge(parameters: charge.Parameters) {
 
         return Credential.serialize({
           challenge,
-          payload: { type: 'hash' as const, hash: result.hash, source },
+          payload: { type: 'hash' as const, hash: result.hash },
+          source,
         })
       }
 
       // Pull mode: send signed XDR for server to broadcast
       return Credential.serialize({
         challenge,
-        payload: { type: 'transaction' as const, transaction: signedXdr, source },
+        payload: { type: 'transaction' as const, transaction: signedXdr },
+        source,
       })
     },
   })

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -4,7 +4,6 @@ import {
   BASE_FEE,
   Contract,
   Keypair,
-  Memo,
   TransactionBuilder,
   authorizeEntry,
   nativeToScVal,
@@ -15,7 +14,9 @@ import { Credential, Method } from 'mppx'
 import { z } from 'zod/mini'
 import {
   ALL_ZEROS,
+  CAIP2_TO_NETWORK,
   DEFAULT_DECIMALS,
+  DEFAULT_LEDGER_CLOSE_TIME,
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
@@ -85,8 +86,10 @@ export function charge(parameters: charge.Parameters) {
     async createCredential({ challenge, context }) {
       const { request } = challenge
       const { amount, currency, recipient } = request
-      const network: NetworkId = (request.methodDetails?.network as NetworkId) ?? 'testnet'
-      const memo = request.methodDetails?.memo as string | undefined
+
+      const caip2Network = request.methodDetails?.network ?? 'stellar:testnet'
+      const network: NetworkId = CAIP2_TO_NETWORK[caip2Network] ?? 'testnet'
+
       onProgress?.({
         type: 'challenge',
         recipient,
@@ -112,6 +115,11 @@ export function charge(parameters: charge.Parameters) {
         )
       }
 
+      // Gap #4: Derive ledger expiration from challenge.expires instead of timeout
+      const expiresTimestamp: number | undefined = challenge.expires
+        ? Math.floor(new Date(challenge.expires).getTime() / 1000)
+        : undefined
+
       if (isServerSponsored) {
         // ── Spec-compliant sponsored path ──────────────────────────────────
         // Client uses an all-zeros source account so the server can swap in
@@ -128,20 +136,33 @@ export function charge(parameters: charge.Parameters) {
         const sponsoredBuilder = new TransactionBuilder(placeholderSource, {
           fee: BASE_FEE,
           networkPassphrase,
-        })
-          .addOperation(transferOp)
-          .setTimeout(timeout)
+        }).addOperation(transferOp)
 
-        if (memo) {
-          sponsoredBuilder.addMemo(Memo.text(memo))
+        // Gap #5: Set timeBounds.maxTime to expires timestamp
+        if (expiresTimestamp) {
+          sponsoredBuilder.setTimeout(0)
+          ;(sponsoredBuilder as any).timeBounds = {
+            minTime: 0,
+            maxTime: expiresTimestamp,
+          }
+        } else {
+          sponsoredBuilder.setTimeout(timeout)
         }
 
         const unsignedTx = sponsoredBuilder.build()
         const prepared = await server.prepareTransaction(unsignedTx)
 
-        // Determine auth-entry expiry from the current ledger sequence
+        // Gap #4: Derive auth-entry expiry from challenge.expires
         const latestLedger = await server.getLatestLedger()
-        const validUntilLedger = latestLedger.sequence + Math.ceil(timeout / 5) + 10
+        let validUntilLedger: number
+        if (expiresTimestamp) {
+          const nowSecs = Math.floor(Date.now() / 1000)
+          const secsUntilExpiry = Math.max(expiresTimestamp - nowSecs, 0)
+          validUntilLedger =
+            latestLedger.sequence + Math.ceil(secsUntilExpiry / DEFAULT_LEDGER_CLOSE_TIME)
+        } else {
+          validUntilLedger = latestLedger.sequence + Math.ceil(timeout / 5) + 10
+        }
 
         onProgress?.({ type: 'signing' })
 
@@ -173,9 +194,13 @@ export function charge(parameters: charge.Parameters) {
         const signedXdr = prepared.toEnvelope().toXDR('base64')
         onProgress?.({ type: 'signed', transaction: signedXdr })
 
+        // Gap #14: Add DID-PKH source field
+        const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
+        const source = `did:pkh:stellar:${caip2Component}:${keypair.publicKey()}`
+
         return Credential.serialize({
           challenge,
-          payload: { type: 'transaction' as const, transaction: signedXdr },
+          payload: { type: 'transaction' as const, transaction: signedXdr, source },
         })
       }
 
@@ -194,12 +219,17 @@ export function charge(parameters: charge.Parameters) {
       const builder = new TransactionBuilder(sourceAccount, {
         fee: BASE_FEE,
         networkPassphrase,
-      })
-        .addOperation(transferOp)
-        .setTimeout(timeout)
+      }).addOperation(transferOp)
 
-      if (memo) {
-        builder.addMemo(Memo.text(memo))
+      // Gap #5: Set timeBounds.maxTime to expires timestamp for unsponsored path
+      if (expiresTimestamp) {
+        builder.setTimeout(0)
+        ;(builder as any).timeBounds = {
+          minTime: 0,
+          maxTime: expiresTimestamp,
+        }
+      } else {
+        builder.setTimeout(timeout)
       }
 
       const transaction = builder.build()
@@ -212,6 +242,10 @@ export function charge(parameters: charge.Parameters) {
 
       const signedXdr = prepared.toXDR()
       onProgress?.({ type: 'signed', transaction: signedXdr })
+
+      // Gap #14: Add DID-PKH source field
+      const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
+      const source = `did:pkh:stellar:${caip2Component}:${keypair.publicKey()}`
 
       if (effectiveMode === 'push') {
         // Client broadcasts
@@ -230,14 +264,14 @@ export function charge(parameters: charge.Parameters) {
 
         return Credential.serialize({
           challenge,
-          payload: { type: 'hash' as const, hash: result.hash },
+          payload: { type: 'hash' as const, hash: result.hash, source },
         })
       }
 
       // Pull mode: send signed XDR for server to broadcast
       return Credential.serialize({
         challenge,
-        payload: { type: 'transaction' as const, transaction: signedXdr },
+        payload: { type: 'transaction' as const, transaction: signedXdr, source },
       })
     },
   })

--- a/sdk/src/charge/integration.test.ts
+++ b/sdk/src/charge/integration.test.ts
@@ -120,3 +120,88 @@ describe('credential type validation', () => {
     expect(serialized).toContain('Payment')
   })
 })
+
+describe('spec compliance: credential structure', () => {
+  it('source is a top-level credential field, not inside payload', () => {
+    const challenge = mockChallenge()
+    const source = `did:pkh:stellar:testnet:${SENDER.publicKey()}`
+
+    const serialized = Credential.serialize({
+      challenge,
+      payload: { type: 'transaction' as const, transaction: 'AAAA' },
+      source,
+    })
+
+    const deserialized = Credential.deserialize(serialized)
+
+    expect(deserialized.source).toBe(source)
+
+    const payload = deserialized.payload as Record<string, unknown>
+    expect(payload.source).toBeUndefined()
+  })
+
+  it('source roundtrips through serialize/deserialize for hash type', () => {
+    const challenge = mockChallenge()
+    const source = `did:pkh:stellar:testnet:${SENDER.publicKey()}`
+
+    const serialized = Credential.serialize({
+      challenge,
+      payload: { type: 'hash' as const, hash: 'tx-hash-abc' },
+      source,
+    })
+
+    const deserialized = Credential.deserialize(serialized)
+    expect(deserialized.source).toBe(source)
+
+    const payload = deserialized.payload as Record<string, unknown>
+    expect(payload.source).toBeUndefined()
+    expect(payload.type).toBe('hash')
+    expect(payload.hash).toBe('tx-hash-abc')
+  })
+
+  it('credential without source omits the field entirely', () => {
+    const challenge = mockChallenge()
+
+    const serialized = Credential.serialize({
+      challenge,
+      payload: { type: 'transaction' as const, transaction: 'AAAA' },
+    })
+
+    const deserialized = Credential.deserialize(serialized)
+    expect(deserialized.source).toBeUndefined()
+  })
+
+  it('source follows DID-PKH format for Stellar', () => {
+    const kp = Keypair.random()
+    const source = `did:pkh:stellar:testnet:${kp.publicKey()}`
+
+    expect(source).toMatch(/^did:pkh:stellar:(testnet|pubnet):G[A-Z2-7]{55}$/)
+  })
+
+  it('payload.type discriminator is preserved without source contamination', () => {
+    const challenge = mockChallenge()
+    const source = `did:pkh:stellar:testnet:${SENDER.publicKey()}`
+
+    const txSerialized = Credential.serialize({
+      challenge,
+      payload: { type: 'transaction' as const, transaction: 'AAAA' },
+      source,
+    })
+    const txDeserialized = Credential.deserialize(txSerialized)
+    const txPayload = txDeserialized.payload as { type: string; transaction?: string }
+    expect(txPayload.type).toBe('transaction')
+    expect(txPayload.transaction).toBe('AAAA')
+    expect(Object.keys(txPayload).sort()).toEqual(['transaction', 'type'])
+
+    const hashSerialized = Credential.serialize({
+      challenge,
+      payload: { type: 'hash' as const, hash: 'deadbeef' },
+      source,
+    })
+    const hashDeserialized = Credential.deserialize(hashSerialized)
+    const hashPayload = hashDeserialized.payload as { type: string; hash?: string }
+    expect(hashPayload.type).toBe('hash')
+    expect(hashPayload.hash).toBe('deadbeef')
+    expect(Object.keys(hashPayload).sort()).toEqual(['hash', 'type'])
+  })
+})

--- a/sdk/src/charge/integration.test.ts
+++ b/sdk/src/charge/integration.test.ts
@@ -21,8 +21,7 @@ function mockChallenge(overrides: Record<string, unknown> = {}) {
       currency: USDC_SAC_TESTNET,
       recipient: RECIPIENT.publicKey(),
       methodDetails: {
-        reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
       },
       ...overrides,
     },

--- a/sdk/src/charge/server/Charge.test.ts
+++ b/sdk/src/charge/server/Charge.test.ts
@@ -114,6 +114,71 @@ describe('stellar server charge', () => {
 })
 
 // ---------------------------------------------------------------------------
+// request() transform — CAIP-2 network format
+// ---------------------------------------------------------------------------
+
+describe('charge request transform', () => {
+  it('emits CAIP-2 network in methodDetails (testnet)', () => {
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: USDC_SAC_TESTNET,
+      network: 'testnet',
+    })
+    const transformed = (method as any).request({
+      request: { amount: '1', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },
+    })
+    expect(transformed.methodDetails.network).toBe('stellar:testnet')
+  })
+
+  it('emits CAIP-2 network in methodDetails (pubnet)', () => {
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: USDC_SAC_TESTNET,
+      network: 'public',
+    })
+    const transformed = (method as any).request({
+      request: { amount: '1', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },
+    })
+    expect(transformed.methodDetails.network).toBe('stellar:pubnet')
+  })
+
+  it('includes feePayer when signer is configured', () => {
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: USDC_SAC_TESTNET,
+      signer: Keypair.random(),
+    })
+    const transformed = (method as any).request({
+      request: { amount: '1', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },
+    })
+    expect(transformed.methodDetails.feePayer).toBe(true)
+  })
+
+  it('omits feePayer when no signer configured', () => {
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: USDC_SAC_TESTNET,
+    })
+    const transformed = (method as any).request({
+      request: { amount: '1', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },
+    })
+    expect(transformed.methodDetails.feePayer).toBeUndefined()
+  })
+
+  it('converts amount to base units using decimals', () => {
+    const method = charge({
+      recipient: RECIPIENT,
+      currency: USDC_SAC_TESTNET,
+      decimals: 7,
+    })
+    const transformed = (method as any).request({
+      request: { amount: '0.01', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },
+    })
+    expect(transformed.amount).toBe('100000')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Transaction hash dedup tests (hash flow with mocked RPC)
 // ---------------------------------------------------------------------------
 
@@ -127,6 +192,9 @@ function makeHashCredential(opts: { hash: string; challengeId?: string }) {
       amount: '10000000',
       currency: USDC_SAC_TESTNET,
       recipient: RECIPIENT,
+      methodDetails: {
+        network: 'stellar:testnet',
+      },
     },
   })
   return Credential.from({
@@ -137,10 +205,9 @@ function makeHashCredential(opts: { hash: string; challengeId?: string }) {
 
 describe('charge tx hash dedup', () => {
   it('rejects a second verify with the same tx hash', async () => {
-    // Mock: tx SUCCESS with a valid SAC transfer envelope
     mockGetTransaction.mockResolvedValue({
       status: 'SUCCESS',
-      envelopeXdr: undefined, // verifySacTransfer will throw — that's fine for
+      envelopeXdr: undefined,
     })
 
     const store = Store.memory()
@@ -152,14 +219,11 @@ describe('charge tx hash dedup', () => {
 
     const hash = 'abc123firstuse'
 
-    // First attempt — will fail on envelope verification (no envelope),
-    // which means the hash should NOT be marked as used (write is after verify).
     const cred1 = makeHashCredential({ hash })
     await expect(
       method.verify({ credential: cred1 as any, request: cred1.challenge.request }),
     ).rejects.toThrow()
 
-    // Verify the hash was NOT stored (failed verification should not burn it)
     const stored = await store.get(`stellar:charge:hash:${hash}`)
     expect(stored).toBeFalsy()
   })
@@ -167,7 +231,6 @@ describe('charge tx hash dedup', () => {
   it('marks tx hash as used only after successful verification', async () => {
     const store = Store.memory()
 
-    // Pre-populate the hash to simulate it already being used
     const hash = 'already-used-hash'
     await store.put(`stellar:charge:hash:${hash}`, { usedAt: new Date().toISOString() })
 

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -26,7 +26,7 @@ import { pollTransaction } from '../../shared/poll.js'
 import { wrapFeeBump } from '../../shared/fee-bump.js'
 import { PaymentVerificationError, SettlementError } from '../../shared/errors.js'
 import { noopLogger, type Logger } from '../../shared/logger.js'
-import { SimulationNetworkError, SimulationTimeoutError } from '../../shared/simulate.js'
+import { SimulationContractError, simulateCall } from '../../shared/simulate.js'
 import {
   DEFAULT_MAX_FEE_BUMP_STROOPS,
   DEFAULT_POLL_MAX_ATTEMPTS,
@@ -333,41 +333,18 @@ export function charge(parameters: charge.Parameters) {
     expectedRecipient: string,
     serverAddress: string | undefined,
   ) {
-    let simResponse: rpc.Api.SimulateTransactionResponse
+    let simResponse: rpc.Api.SimulateTransactionSuccessResponse
     try {
-      simResponse = await Promise.race([
-        server.simulateTransaction(tx),
-        new Promise<never>((_, reject) => {
-          setTimeout(
-            () =>
-              reject(
-                new SimulationTimeoutError(`Simulation timed out after ${simulationTimeoutMs}ms`),
-              ),
-            simulationTimeoutMs,
-          )
-        }),
-      ])
+      simResponse = await simulateCall(server, tx, { timeoutMs: simulationTimeoutMs })
     } catch (error) {
-      // Gap #17: RPC unavailability → 5xx, not verification-failed
-      if (error instanceof SimulationNetworkError || error instanceof SimulationTimeoutError) {
-        throw error
-      }
-      // Network-level errors (fetch failures, timeouts) bubble as-is
-      if (error instanceof Error && !error.message.includes('[stellar:charge]')) {
-        throw new SimulationNetworkError(
-          `[stellar:charge] RPC unavailable during simulation: ${error.message}`,
-          error,
+      if (error instanceof SimulationContractError) {
+        throw new PaymentVerificationError(
+          `[stellar:charge] Pre-submission simulation failed: ${error.simulationError}`,
+          { simulationError: error.simulationError },
         )
       }
+      // Timeout and network errors bubble up as-is (Gap #17: RPC unavailability → 5xx)
       throw error
-    }
-
-    if (!rpc.Api.isSimulationSuccess(simResponse)) {
-      const errorMsg = 'error' in simResponse ? String((simResponse as any).error) : 'unknown error'
-      throw new PaymentVerificationError(
-        `[stellar:charge] Pre-submission simulation failed: ${errorMsg}`,
-        { simulationError: errorMsg },
-      )
     }
 
     // Validate simulation events for expected transfer

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -35,6 +35,9 @@ import {
   DEFAULT_SIMULATION_TIMEOUT_MS,
 } from '../../shared/defaults.js'
 
+const LOG_PREFIX = '[stellar:charge]'
+const STORE_PREFIX = 'stellar:charge'
+
 export function charge(parameters: charge.Parameters) {
   const {
     currency,
@@ -97,12 +100,10 @@ export function charge(parameters: charge.Parameters) {
     const { request: challengeRequest } = challenge
 
     if (store) {
-      const key = `stellar:charge:challenge:${challenge.id}`
+      const key = `${STORE_PREFIX}:challenge:${challenge.id}`
       const existing = await store.get(key)
       if (existing) {
-        throw new PaymentVerificationError(
-          '[stellar:charge] Challenge already used. Replay rejected.',
-        )
+        throw new PaymentVerificationError(`${LOG_PREFIX} Challenge already used. Replay rejected.`)
       }
       await store.put(key, { usedAt: new Date().toISOString() })
     }
@@ -122,15 +123,15 @@ export function charge(parameters: charge.Parameters) {
         // early, but only mark as used AFTER successful verification to
         // avoid permanently burning a hash on transient failures.
         if (store) {
-          const hashKey = `stellar:charge:hash:${hash}`
+          const hashKey = `${STORE_PREFIX}:hash:${hash}`
           const hashUsed = await store.get(hashKey)
           if (hashUsed) {
-            logger.warn('[stellar:charge] Verification failed', {
+            logger.warn(`${LOG_PREFIX} Verification failed`, {
               error: 'Transaction hash already used',
               hash,
             })
             throw new PaymentVerificationError(
-              '[stellar:charge] Transaction hash already used. Replay rejected.',
+              `${LOG_PREFIX} Transaction hash already used. Replay rejected.`,
               {
                 hash,
               },
@@ -156,7 +157,7 @@ export function charge(parameters: charge.Parameters) {
 
         // Mark tx hash as used only after successful verification
         if (store) {
-          await store.put(`stellar:charge:hash:${hash}`, { usedAt: new Date().toISOString() })
+          await store.put(`${STORE_PREFIX}:hash:${hash}`, { usedAt: new Date().toISOString() })
         }
 
         return Receipt.from({
@@ -187,11 +188,11 @@ export function charge(parameters: charge.Parameters) {
           | FeeBumpTransaction
 
         if (!signerKeypair && tx.source === ALL_ZEROS) {
-          logger.warn('[stellar:charge] Verification failed', {
+          logger.warn(`${LOG_PREFIX} Verification failed`, {
             error: 'Sponsored source without signer',
           })
           throw new PaymentVerificationError(
-            '[stellar:charge] Transaction uses a sponsored source account but the server is not configured with a signer.',
+            `${LOG_PREFIX} Transaction uses a sponsored source account but the server is not configured with a signer.`,
             {},
           )
         }
@@ -207,7 +208,7 @@ export function charge(parameters: charge.Parameters) {
           await validateAuthEntries(tx, signerKeypair.publicKey(), expiresTimestamp)
 
           // Rebuild the tx with the signer's account as source
-          logger.debug('[stellar:charge] Rebuilding sponsored tx...')
+          logger.debug(`${LOG_PREFIX} Rebuilding sponsored tx...`)
           const serverAccount = await server.getAccount(signerKeypair.publicKey())
           const envelopeTx = tx.toEnvelope().v1().tx()
           const sorobanData = envelopeTx.ext().sorobanData()
@@ -242,7 +243,7 @@ export function charge(parameters: charge.Parameters) {
             const maxTime = parseInt(tx.timeBounds.maxTime, 10)
             if (maxTime > expiresTimestamp) {
               throw new PaymentVerificationError(
-                '[stellar:charge] Transaction timeBounds.maxTime exceeds challenge expires.',
+                `${LOG_PREFIX} Transaction timeBounds.maxTime exceeds challenge expires.`,
                 {
                   maxTime,
                   expires: expiresTimestamp,
@@ -262,7 +263,7 @@ export function charge(parameters: charge.Parameters) {
 
         // ── Fee bump wrapping ───────────────────────────────────────
         if (feeBumpKeypair) {
-          logger.debug('[stellar:charge] Fee bump wrapping')
+          logger.debug(`${LOG_PREFIX} Fee bump wrapping`)
           txToSubmit = wrapFeeBump(txToSubmit, feeBumpKeypair, {
             networkPassphrase,
             maxFeeStroops: maxFeeBumpStroops,
@@ -272,12 +273,12 @@ export function charge(parameters: charge.Parameters) {
         // ── Settlement ──────────────────────────────────────────────
         let sendResult: rpc.Api.SendTransactionResponse
         try {
-          logger.debug('[stellar:charge] Broadcasting tx')
+          logger.debug(`${LOG_PREFIX} Broadcasting tx`)
           sendResult = await server.sendTransaction(txToSubmit)
-          logger.debug('[stellar:charge] Broadcasting tx', { hash: sendResult.hash })
+          logger.debug(`${LOG_PREFIX} Broadcasting tx`, { hash: sendResult.hash })
         } catch (error) {
           throw new SettlementError(
-            '[stellar:charge] Settlement failed: could not broadcast transaction.',
+            `${LOG_PREFIX} Settlement failed: could not broadcast transaction.`,
             {
               details: error instanceof Error ? error.message : String(error),
             },
@@ -291,13 +292,10 @@ export function charge(parameters: charge.Parameters) {
             timeoutMs: pollTimeoutMs,
           })
         } catch (error) {
-          throw new SettlementError(
-            '[stellar:charge] Settlement failed: transaction not confirmed.',
-            {
-              hash: sendResult.hash,
-              details: error instanceof Error ? error.message : String(error),
-            },
-          )
+          throw new SettlementError(`${LOG_PREFIX} Settlement failed: transaction not confirmed.`, {
+            hash: sendResult.hash,
+            details: error instanceof Error ? error.message : String(error),
+          })
         }
 
         return Receipt.from({
@@ -330,7 +328,7 @@ export function charge(parameters: charge.Parameters) {
     } catch (error) {
       if (error instanceof SimulationContractError) {
         throw new PaymentVerificationError(
-          `[stellar:charge] Pre-submission simulation failed: ${error.simulationError}`,
+          `${LOG_PREFIX} Pre-submission simulation failed: ${error.simulationError}`,
           { simulationError: error.simulationError },
         )
       }
@@ -396,7 +394,7 @@ export function charge(parameters: charge.Parameters) {
         const entryAddress = Address.fromScAddress(addressCred.address())
         if (entryAddress.toString() === serverAddress.toString()) {
           throw new PaymentVerificationError(
-            '[stellar:charge] Server address must not appear in client auth entries.',
+            `${LOG_PREFIX} Server address must not appear in client auth entries.`,
             { serverAddress: serverPublicKey },
           )
         }
@@ -405,7 +403,7 @@ export function charge(parameters: charge.Parameters) {
           const entryExpiration = addressCred.signatureExpirationLedger()
           if (entryExpiration > maxLedger) {
             throw new PaymentVerificationError(
-              '[stellar:charge] Auth entry expiration exceeds maximum allowed ledger.',
+              `${LOG_PREFIX} Auth entry expiration exceeds maximum allowed ledger.`,
               {
                 entryExpiration,
                 maxLedger,
@@ -417,7 +415,7 @@ export function charge(parameters: charge.Parameters) {
         const rootInvocation = entry.rootInvocation()
         if (rootInvocation.subInvocations().length > 0) {
           throw new PaymentVerificationError(
-            '[stellar:charge] Auth entries must not contain sub-invocations.',
+            `${LOG_PREFIX} Auth entries must not contain sub-invocations.`,
             {},
           )
         }
@@ -435,13 +433,13 @@ function verifyExactlyOneInvokeOp(tx: Transaction) {
 
   if (invokeOps.length === 0) {
     throw new PaymentVerificationError(
-      '[stellar:charge] Transaction does not contain a Soroban invocation.',
+      `${LOG_PREFIX} Transaction does not contain a Soroban invocation.`,
       {},
     )
   }
   if (invokeOps.length > 1) {
     throw new PaymentVerificationError(
-      '[stellar:charge] Transaction must contain exactly one invokeHostFunction operation.',
+      `${LOG_PREFIX} Transaction must contain exactly one invokeHostFunction operation.`,
       { operationCount: invokeOps.length },
     )
   }
@@ -496,7 +494,7 @@ function verifyFromRawOps(
 
   if (!found) {
     throw new PaymentVerificationError(
-      '[stellar:charge] Transaction does not contain a matching SAC transfer invocation.',
+      `${LOG_PREFIX} Transaction does not contain a matching SAC transfer invocation.`,
       {
         currency: expected.currency,
         recipient: expected.recipient,
@@ -513,7 +511,7 @@ function verifySacTransfer(
 ) {
   if (!txResult.envelopeXdr) {
     throw new PaymentVerificationError(
-      '[stellar:charge] Transaction result is missing envelope XDR — cannot verify payment.',
+      `${LOG_PREFIX} Transaction result is missing envelope XDR — cannot verify payment.`,
       {},
     )
   }
@@ -524,7 +522,7 @@ function verifySacTransfer(
       envelope = xdr.TransactionEnvelope.fromXDR(txResult.envelopeXdr, 'base64')
     } catch (error) {
       throw new PaymentVerificationError(
-        '[stellar:charge] Could not parse transaction envelope for verification.',
+        `${LOG_PREFIX} Could not parse transaction envelope for verification.`,
         {
           details: error instanceof Error ? error.message : String(error),
         },
@@ -539,7 +537,7 @@ function verifySacTransfer(
     innerTx = new Transaction(envelope, networkPassphrase)
   } catch {
     throw new PaymentVerificationError(
-      '[stellar:charge] Could not parse transaction envelope for verification.',
+      `${LOG_PREFIX} Could not parse transaction envelope for verification.`,
       {},
     )
   }
@@ -600,7 +598,7 @@ function validateSimulationEvents(
 
   if (!matchingTransfer) {
     throw new PaymentVerificationError(
-      '[stellar:charge] Simulation events do not contain expected transfer.',
+      `${LOG_PREFIX} Simulation events do not contain expected transfer.`,
       {
         expectedRecipient,
         expectedAmount: expectedAmount.toString(),
@@ -616,7 +614,7 @@ function validateSimulationEvents(
     )
     if (serverInvolved) {
       throw new PaymentVerificationError(
-        '[stellar:charge] Server address must not be involved in transfer events.',
+        `${LOG_PREFIX} Server address must not be involved in transfer events.`,
         { serverAddress },
       )
     }

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -10,7 +10,9 @@ import {
 import { Method, Receipt, Store } from 'mppx'
 import {
   ALL_ZEROS,
+  CAIP2_NETWORK,
   DEFAULT_DECIMALS,
+  DEFAULT_LEDGER_CLOSE_TIME,
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
@@ -22,8 +24,9 @@ import { scValToBigInt } from '../../shared/scval.js'
 import { resolveKeypair } from '../../shared/keypairs.js'
 import { pollTransaction } from '../../shared/poll.js'
 import { wrapFeeBump } from '../../shared/fee-bump.js'
-import { PaymentVerificationError } from '../../shared/errors.js'
+import { PaymentVerificationError, SettlementError } from '../../shared/errors.js'
 import { noopLogger, type Logger } from '../../shared/logger.js'
+import { SimulationNetworkError, SimulationTimeoutError } from '../../shared/simulate.js'
 import {
   DEFAULT_MAX_FEE_BUMP_STROOPS,
   DEFAULT_POLL_MAX_ATTEMPTS,
@@ -45,7 +48,7 @@ export function charge(parameters: charge.Parameters) {
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
     recipient,
     rpcUrl,
-    simulationTimeoutMs: _simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
+    simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
     signer: signerParam,
     store,
   } = parameters
@@ -72,9 +75,7 @@ export function charge(parameters: charge.Parameters) {
         ...request,
         amount: toBaseUnits(request.amount, decimals),
         methodDetails: {
-          ...request.methodDetails,
-          reference: crypto.randomUUID(),
-          network,
+          network: CAIP2_NETWORK[network],
           ...(signerKeypair ? { feePayer: true } : {}),
         },
       }
@@ -173,6 +174,9 @@ export function charge(parameters: charge.Parameters) {
         const tx =
           parsed instanceof FeeBumpTransaction ? parsed.innerTransaction : (parsed as Transaction)
 
+        // Gap #13: Exactly one invokeHostFunction operation
+        verifyExactlyOneInvokeOp(tx)
+
         verifySacInvocation(tx, {
           amount: expectedAmount,
           currency: expectedCurrency,
@@ -193,10 +197,20 @@ export function charge(parameters: charge.Parameters) {
           )
         }
 
+        // Determine expires from challenge for ledger expiration calculations
+        const expiresTimestamp: number | undefined = challenge.expires
+          ? Math.floor(new Date(challenge.expires).getTime() / 1000)
+          : undefined
+
         if (signerKeypair && tx.source === ALL_ZEROS) {
           // ── Sponsored path ──────────────────────────────────────────
-          // Client used all-zeros source; rebuild the tx with the
-          // signer's account as source.
+
+          // Gap #8: Auth entries MUST NOT contain subInvocations
+          // Gap #9: Auth entry expiration MUST NOT exceed max ledger
+          // Gap #10: Server address MUST NOT appear in auth entries
+          await validateAuthEntries(tx, signerKeypair.publicKey(), expiresTimestamp)
+
+          // Rebuild the tx with the signer's account as source
           logger.debug('[stellar:charge] Rebuilding sponsored tx...')
           const serverAccount = await server.getAccount(signerKeypair.publicKey())
           const envelopeTx = tx.toEnvelope().v1().tx()
@@ -214,14 +228,46 @@ export function charge(parameters: charge.Parameters) {
             rebuilt.setTimeout(DEFAULT_TIMEOUT)
           }
           const rebuiltTx = rebuilt.setSorobanData(sorobanData).build()
+
+          // Gap #6 & #7: Pre-submission simulation + re-simulation after rebuild
+          await simulateAndValidateTransfer(
+            rebuiltTx,
+            expectedAmount,
+            expectedCurrency,
+            expectedRecipient,
+            signerKeypair.publicKey(),
+          )
+
           rebuiltTx.sign(signerKeypair)
           txToSubmit = rebuiltTx
+        } else {
+          // ── Unsponsored path ────────────────────────────────────────
+
+          // Gap #11: timeBounds.maxTime MUST NOT exceed expires
+          if (expiresTimestamp && tx.timeBounds) {
+            const maxTime = parseInt(tx.timeBounds.maxTime, 10)
+            if (maxTime > expiresTimestamp) {
+              throw new PaymentVerificationError(
+                '[stellar:charge] Transaction timeBounds.maxTime exceeds challenge expires.',
+                {
+                  maxTime,
+                  expires: expiresTimestamp,
+                },
+              )
+            }
+          }
+
+          // Gap #6: Pre-submission simulation
+          await simulateAndValidateTransfer(
+            tx,
+            expectedAmount,
+            expectedCurrency,
+            expectedRecipient,
+            signerKeypair?.publicKey(),
+          )
         }
 
         // ── Fee bump wrapping ───────────────────────────────────────
-        // When feeBumpSigner is set, wrap in a FeeBumpTransaction.
-        // Applies to both sponsored and unsponsored paths.
-        // NM-004: Cap the fee-bump to prevent draining the fee payer.
         if (feeBumpKeypair) {
           logger.debug('[stellar:charge] Fee bump wrapping')
           txToSubmit = wrapFeeBump(txToSubmit, feeBumpKeypair, {
@@ -230,15 +276,37 @@ export function charge(parameters: charge.Parameters) {
           })
         }
 
-        logger.debug('[stellar:charge] Broadcasting tx')
-        const sendResult = await server.sendTransaction(txToSubmit)
-        logger.debug('[stellar:charge] Broadcasting tx', { hash: sendResult.hash })
+        // ── Settlement ──────────────────────────────────────────────
+        // Gap #12: Use SettlementError for broadcast/confirmation failures
+        let sendResult: rpc.Api.SendTransactionResponse
+        try {
+          logger.debug('[stellar:charge] Broadcasting tx')
+          sendResult = await server.sendTransaction(txToSubmit)
+          logger.debug('[stellar:charge] Broadcasting tx', { hash: sendResult.hash })
+        } catch (error) {
+          throw new SettlementError(
+            '[stellar:charge] Settlement failed: could not broadcast transaction.',
+            {
+              details: error instanceof Error ? error.message : String(error),
+            },
+          )
+        }
 
-        await pollTransaction(server, sendResult.hash, {
-          maxAttempts: pollMaxAttempts,
-          delayMs: pollDelayMs,
-          timeoutMs: pollTimeoutMs,
-        })
+        try {
+          await pollTransaction(server, sendResult.hash, {
+            maxAttempts: pollMaxAttempts,
+            delayMs: pollDelayMs,
+            timeoutMs: pollTimeoutMs,
+          })
+        } catch (error) {
+          throw new SettlementError(
+            '[stellar:charge] Settlement failed: transaction not confirmed.',
+            {
+              hash: sendResult.hash,
+              details: error instanceof Error ? error.message : String(error),
+            },
+          )
+        }
 
         return Receipt.from({
           method: 'stellar',
@@ -254,25 +322,171 @@ export function charge(parameters: charge.Parameters) {
         )
     }
   }
+
+  // ── Simulation validation ─────────────────────────────────────────────
+  // Gap #6 & #7: Server MUST simulate before submitting; validate events
+
+  async function simulateAndValidateTransfer(
+    tx: Transaction,
+    expectedAmount: bigint,
+    expectedCurrency: string,
+    expectedRecipient: string,
+    serverAddress: string | undefined,
+  ) {
+    let simResponse: rpc.Api.SimulateTransactionResponse
+    try {
+      simResponse = await Promise.race([
+        server.simulateTransaction(tx),
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () =>
+              reject(
+                new SimulationTimeoutError(`Simulation timed out after ${simulationTimeoutMs}ms`),
+              ),
+            simulationTimeoutMs,
+          )
+        }),
+      ])
+    } catch (error) {
+      // Gap #17: RPC unavailability → 5xx, not verification-failed
+      if (error instanceof SimulationNetworkError || error instanceof SimulationTimeoutError) {
+        throw error
+      }
+      // Network-level errors (fetch failures, timeouts) bubble as-is
+      if (error instanceof Error && !error.message.includes('[stellar:charge]')) {
+        throw new SimulationNetworkError(
+          `[stellar:charge] RPC unavailable during simulation: ${error.message}`,
+          error,
+        )
+      }
+      throw error
+    }
+
+    if (!rpc.Api.isSimulationSuccess(simResponse)) {
+      const errorMsg = 'error' in simResponse ? String((simResponse as any).error) : 'unknown error'
+      throw new PaymentVerificationError(
+        `[stellar:charge] Pre-submission simulation failed: ${errorMsg}`,
+        { simulationError: errorMsg },
+      )
+    }
+
+    // Validate simulation events for expected transfer
+    if (simResponse.events && simResponse.events.length > 0) {
+      validateSimulationEvents(
+        simResponse.events,
+        expectedAmount,
+        expectedCurrency,
+        expectedRecipient,
+        serverAddress,
+      )
+    }
+  }
+
+  // ── Auth entry validation (sponsored path) ────────────────────────────
+
+  async function validateAuthEntries(
+    tx: Transaction,
+    serverPublicKey: string,
+    expiresTimestamp: number | undefined,
+  ) {
+    const envelope = tx.toEnvelope().v1().tx()
+    const ops = envelope.operations()
+
+    // Calculate max ledger from expires
+    let maxLedger: number | undefined
+    if (expiresTimestamp) {
+      const nowSecs = Math.floor(Date.now() / 1000)
+      const secsUntilExpiry = expiresTimestamp - nowSecs
+      if (secsUntilExpiry > 0) {
+        const latestLedger = await server.getLatestLedger()
+        maxLedger = latestLedger.sequence + Math.ceil(secsUntilExpiry / DEFAULT_LEDGER_CLOSE_TIME)
+      }
+    }
+
+    const serverAddress = Address.fromString(serverPublicKey)
+
+    for (let i = 0; i < ops.length; i++) {
+      const opBody = ops[i].body()
+      if (opBody.switch().value !== xdr.OperationType.invokeHostFunction().value) {
+        continue
+      }
+
+      const authEntries = opBody.invokeHostFunctionOp().auth()
+      for (const entry of authEntries) {
+        const credentials = entry.credentials()
+
+        // Only validate address-type credentials
+        if (
+          credentials.switch().value !==
+          xdr.SorobanCredentialsType.sorobanCredentialsAddress().value
+        ) {
+          continue
+        }
+
+        const addressCred = credentials.address()
+
+        // Gap #10: Server's address MUST NOT appear in auth entries
+        const entryAddress = Address.fromScAddress(addressCred.address())
+        if (entryAddress.toString() === serverAddress.toString()) {
+          throw new PaymentVerificationError(
+            '[stellar:charge] Server address must not appear in client auth entries.',
+            { serverAddress: serverPublicKey },
+          )
+        }
+
+        // Gap #9: Expiration MUST NOT exceed maxLedger
+        if (maxLedger !== undefined) {
+          const entryExpiration = addressCred.signatureExpirationLedger()
+          if (entryExpiration > maxLedger) {
+            throw new PaymentVerificationError(
+              '[stellar:charge] Auth entry expiration exceeds maximum allowed ledger.',
+              {
+                entryExpiration,
+                maxLedger,
+              },
+            )
+          }
+        }
+
+        // Gap #8: MUST NOT contain subInvocations
+        const rootInvocation = entry.rootInvocation()
+        if (rootInvocation.subInvocations().length > 0) {
+          throw new PaymentVerificationError(
+            '[stellar:charge] Auth entries must not contain sub-invocations.',
+            {},
+          )
+        }
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Verification helpers
 // ---------------------------------------------------------------------------
 
-function verifySacInvocation(
-  tx: Transaction,
-  expected: { amount: bigint; currency: string; recipient: string },
-) {
-  const invokeOp = tx.operations.find((op) => op.type === 'invokeHostFunction')
+// Gap #13: Transaction MUST contain exactly one invokeHostFunction operation
+function verifyExactlyOneInvokeOp(tx: Transaction) {
+  const invokeOps = tx.operations.filter((op) => op.type === 'invokeHostFunction')
 
-  if (!invokeOp) {
+  if (invokeOps.length === 0) {
     throw new PaymentVerificationError(
       '[stellar:charge] Transaction does not contain a Soroban invocation.',
       {},
     )
   }
+  if (invokeOps.length > 1) {
+    throw new PaymentVerificationError(
+      '[stellar:charge] Transaction must contain exactly one invokeHostFunction operation.',
+      { operationCount: invokeOps.length },
+    )
+  }
+}
 
+function verifySacInvocation(
+  tx: Transaction,
+  expected: { amount: bigint; currency: string; recipient: string },
+) {
   verifyFromRawOps(tx, expected)
 }
 
@@ -356,7 +570,6 @@ function verifySacTransfer(
     envelope = txResult.envelopeXdr
   }
 
-  // NM-009: Use the configured network passphrase instead of guessing.
   let innerTx: Transaction
   try {
     innerTx = new Transaction(envelope, networkPassphrase)
@@ -371,6 +584,82 @@ function verifySacTransfer(
 }
 
 // ---------------------------------------------------------------------------
+// Simulation event validation (CAP-46 transfer events)
+// ---------------------------------------------------------------------------
+
+function validateSimulationEvents(
+  events: xdr.DiagnosticEvent[],
+  expectedAmount: bigint,
+  expectedCurrency: string,
+  expectedRecipient: string,
+  serverAddress: string | undefined,
+) {
+  const transferEvents: Array<{ from: string; to: string; amount: bigint; contract: string }> = []
+
+  for (const event of events) {
+    try {
+      const contractEvent = event.event()
+      // Only process contract events (type 0)
+      if (contractEvent.type().value !== 0) continue
+
+      const body = contractEvent.body().v0()
+      const topics = body.topics()
+      if (topics.length < 3) continue
+
+      // CAP-46: topic[0] = "transfer"
+      const topicName = topics[0].sym?.()?.toString()
+      if (topicName !== 'transfer') continue
+
+      const from = Address.fromScVal(topics[1]).toString()
+      const to = Address.fromScVal(topics[2]).toString()
+      const amount = scValToBigInt(body.data())
+      const contract = contractEvent.contractId()
+        ? Address.fromScAddress(
+            xdr.ScAddress.scAddressTypeContract(contractEvent.contractId()!),
+          ).toString()
+        : ''
+
+      transferEvents.push({ from, to, amount, contract })
+    } catch {
+      // Skip events we can't parse
+      continue
+    }
+  }
+
+  if (transferEvents.length === 0) return
+
+  // Verify at least one transfer matches expected parameters
+  const matchingTransfer = transferEvents.find(
+    (t) =>
+      t.to === expectedRecipient && t.amount === expectedAmount && t.contract === expectedCurrency,
+  )
+
+  if (!matchingTransfer) {
+    throw new PaymentVerificationError(
+      '[stellar:charge] Simulation events do not contain expected transfer.',
+      {
+        expectedRecipient,
+        expectedAmount: expectedAmount.toString(),
+        expectedCurrency,
+      },
+    )
+  }
+
+  // Server address must not be involved in transfers (Gap #10 reinforcement)
+  if (serverAddress) {
+    const serverInvolved = transferEvents.some(
+      (t) => t.from === serverAddress || t.to === serverAddress,
+    )
+    if (serverInvolved) {
+      throw new PaymentVerificationError(
+        '[stellar:charge] Server address must not be involved in transfer events.',
+        { serverAddress },
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -381,26 +670,14 @@ export declare namespace charge {
     decimals?: number
     network?: NetworkId
     rpcUrl?: string
-    /** Keypair providing source account for sponsored transactions. */
     signer?: Keypair | string
-    /**
-     * Optional fee bump signer. Wraps non-fee-bump transactions in a
-     * FeeBumpTransaction; if a FeeBumpTransaction is already provided, it is
-     * submitted as-is.
-     */
     feeBumpSigner?: Keypair | string
     store?: Store.Store
-    /** Maximum fee bump in stroops. @default 10_000_000 */
     maxFeeBumpStroops?: number
-    /** Maximum polling attempts. @default 30 */
     pollMaxAttempts?: number
-    /** Delay between poll attempts in ms. @default 1_000 */
     pollDelayMs?: number
-    /** Overall poll timeout in ms. @default 30_000 */
     pollTimeoutMs?: number
-    /** Simulation timeout in ms. @default 10_000 */
     simulationTimeoutMs?: number
-    /** Logger instance. @default noopLogger */
     logger?: Logger
   }
 }

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -174,7 +174,6 @@ export function charge(parameters: charge.Parameters) {
         const tx =
           parsed instanceof FeeBumpTransaction ? parsed.innerTransaction : (parsed as Transaction)
 
-        // Gap #13: Exactly one invokeHostFunction operation
         verifyExactlyOneInvokeOp(tx)
 
         verifySacInvocation(tx, {
@@ -205,9 +204,6 @@ export function charge(parameters: charge.Parameters) {
         if (signerKeypair && tx.source === ALL_ZEROS) {
           // ── Sponsored path ──────────────────────────────────────────
 
-          // Gap #8: Auth entries MUST NOT contain subInvocations
-          // Gap #9: Auth entry expiration MUST NOT exceed max ledger
-          // Gap #10: Server address MUST NOT appear in auth entries
           await validateAuthEntries(tx, signerKeypair.publicKey(), expiresTimestamp)
 
           // Rebuild the tx with the signer's account as source
@@ -229,7 +225,6 @@ export function charge(parameters: charge.Parameters) {
           }
           const rebuiltTx = rebuilt.setSorobanData(sorobanData).build()
 
-          // Gap #6 & #7: Pre-submission simulation + re-simulation after rebuild
           await simulateAndValidateTransfer(
             rebuiltTx,
             expectedAmount,
@@ -243,7 +238,6 @@ export function charge(parameters: charge.Parameters) {
         } else {
           // ── Unsponsored path ────────────────────────────────────────
 
-          // Gap #11: timeBounds.maxTime MUST NOT exceed expires
           if (expiresTimestamp && tx.timeBounds) {
             const maxTime = parseInt(tx.timeBounds.maxTime, 10)
             if (maxTime > expiresTimestamp) {
@@ -257,7 +251,6 @@ export function charge(parameters: charge.Parameters) {
             }
           }
 
-          // Gap #6: Pre-submission simulation
           await simulateAndValidateTransfer(
             tx,
             expectedAmount,
@@ -277,7 +270,6 @@ export function charge(parameters: charge.Parameters) {
         }
 
         // ── Settlement ──────────────────────────────────────────────
-        // Gap #12: Use SettlementError for broadcast/confirmation failures
         let sendResult: rpc.Api.SendTransactionResponse
         try {
           logger.debug('[stellar:charge] Broadcasting tx')
@@ -324,7 +316,6 @@ export function charge(parameters: charge.Parameters) {
   }
 
   // ── Simulation validation ─────────────────────────────────────────────
-  // Gap #6 & #7: Server MUST simulate before submitting; validate events
 
   async function simulateAndValidateTransfer(
     tx: Transaction,
@@ -343,7 +334,7 @@ export function charge(parameters: charge.Parameters) {
           { simulationError: error.simulationError },
         )
       }
-      // Timeout and network errors bubble up as-is (Gap #17: RPC unavailability → 5xx)
+      // Timeout and network errors bubble up as-is
       throw error
     }
 
@@ -402,7 +393,6 @@ export function charge(parameters: charge.Parameters) {
 
         const addressCred = credentials.address()
 
-        // Gap #10: Server's address MUST NOT appear in auth entries
         const entryAddress = Address.fromScAddress(addressCred.address())
         if (entryAddress.toString() === serverAddress.toString()) {
           throw new PaymentVerificationError(
@@ -411,7 +401,6 @@ export function charge(parameters: charge.Parameters) {
           )
         }
 
-        // Gap #9: Expiration MUST NOT exceed maxLedger
         if (maxLedger !== undefined) {
           const entryExpiration = addressCred.signatureExpirationLedger()
           if (entryExpiration > maxLedger) {
@@ -425,7 +414,6 @@ export function charge(parameters: charge.Parameters) {
           }
         }
 
-        // Gap #8: MUST NOT contain subInvocations
         const rootInvocation = entry.rootInvocation()
         if (rootInvocation.subInvocations().length > 0) {
           throw new PaymentVerificationError(
@@ -442,7 +430,6 @@ export function charge(parameters: charge.Parameters) {
 // Verification helpers
 // ---------------------------------------------------------------------------
 
-// Gap #13: Transaction MUST contain exactly one invokeHostFunction operation
 function verifyExactlyOneInvokeOp(tx: Transaction) {
   const invokeOps = tx.operations.filter((op) => op.type === 'invokeHostFunction')
 
@@ -622,7 +609,7 @@ function validateSimulationEvents(
     )
   }
 
-  // Server address must not be involved in transfers (Gap #10 reinforcement)
+  // Server address must not be involved in transfers
   if (serverAddress) {
     const serverInvolved = transferEvents.some(
       (t) => t.from === serverAddress || t.to === serverAddress,

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -54,6 +54,27 @@ export const SAC_ADDRESSES = {
 } as const
 
 // ---------------------------------------------------------------------------
+// CAIP-2 network identifiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps internal network IDs to CAIP-2 chain identifiers.
+ * @see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md
+ */
+export const CAIP2_NETWORK: Record<NetworkId, string> = {
+  public: 'stellar:pubnet',
+  testnet: 'stellar:testnet',
+}
+
+/**
+ * Reverse map: CAIP-2 chain identifier → internal NetworkId.
+ */
+export const CAIP2_TO_NETWORK: Record<string, NetworkId> = {
+  'stellar:pubnet': 'public',
+  'stellar:testnet': 'testnet',
+}
+
+// ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
 
@@ -65,6 +86,12 @@ export const DEFAULT_FEE = '100'
 
 /** Default transaction timeout in seconds. */
 export const DEFAULT_TIMEOUT = 180
+
+/** Average Stellar ledger close time in seconds. */
+export const DEFAULT_LEDGER_CLOSE_TIME = 5
+
+/** Default challenge expiry in seconds (5 minutes). */
+export const DEFAULT_CHALLENGE_EXPIRY = 300
 
 // ---------------------------------------------------------------------------
 // Special accounts

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -69,7 +69,7 @@ export const CAIP2_NETWORK: Record<NetworkId, string> = {
 /**
  * Reverse map: CAIP-2 chain identifier → internal NetworkId.
  */
-export const CAIP2_TO_NETWORK: Record<string, NetworkId> = {
+export const CAIP2_TO_NETWORK: Record<string, NetworkId | undefined> = {
   'stellar:pubnet': 'public',
   'stellar:testnet': 'testnet',
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,8 +4,12 @@ export * as ChannelMethods from './channel/Methods.js'
 
 // Constants (public)
 export {
+  CAIP2_NETWORK,
+  CAIP2_TO_NETWORK,
+  DEFAULT_CHALLENGE_EXPIRY,
   DEFAULT_DECIMALS,
   DEFAULT_FEE,
+  DEFAULT_LEDGER_CLOSE_TIME,
   DEFAULT_TIMEOUT,
   HORIZON_URLS,
   NETWORK_PASSPHRASE,
@@ -30,3 +34,6 @@ export * as Env from './env.js'
 
 // Logger interface (public — consumers need the type)
 export type { Logger } from './shared/logger.js'
+
+// Error types (public)
+export { SettlementError } from './shared/errors.js'

--- a/sdk/src/shared/errors.ts
+++ b/sdk/src/shared/errors.ts
@@ -10,4 +10,6 @@ export class StellarMppError extends Error {
 
 export class PaymentVerificationError extends StellarMppError {}
 
+export class SettlementError extends StellarMppError {}
+
 export class ChannelVerificationError extends StellarMppError {}


### PR DESCRIPTION
## What

- Switch network identifiers to CAIP-2 format (`stellar:testnet` / `stellar:pubnet`) in `methodDetails.network` and credential `source` field; add `CAIP2_NETWORK` / `CAIP2_TO_NETWORK` constants exported from root index
- Remove `reference` and `memo` fields from `methodDetails` schema
- Move `source` (DID-PKH) from inside `payload` to the top-level credential field
- Add `SettlementError` (exported) to distinguish broadcast/confirmation failures from verification errors
- Add server-side validation for spec gaps:
  - Exactly one `invokeHostFunction` operation
  - Auth entries must not contain sub-invocations
  - Auth entry expiration must not exceed `challenge.expires`
  - Server address must not appear in auth entries or simulation transfer events
  - `timeBounds.maxTime` must not exceed `challenge.expires` on unsponsored path
  - Pre-submission simulation with CAP-46 transfer event validation
  - SettlementError for broadcast and confirmation failures
- Derive ledger expiration from `challenge.expires` instead of a fixed timeout
- Add `DEFAULT_LEDGER_CLOSE_TIME` and `DEFAULT_CHALLENGE_EXPIRY` constants

## Why

The charge module had several gaps relative to `draft-stellar-charge-00`. This PR closes them to improve interoperability and security: CAIP-2 is the spec's standard chain reference format; the DID-PKH `source` must be a top-level credential field (the `mppx` `Credential` type already modeled this correctly but the client was placing it inside `payload`); the server must validate transaction structure and auth entries before broadcasting to prevent abuse.

## API changes (before → after)

**`methodDetails.network` — CAIP-2 format**
```diff
- { network: 'testnet' }
+ { network: 'stellar:testnet' }
```

**Credential `source` field — moved to top level**
```diff
- Credential.serialize({ challenge, payload: { type: 'transaction', transaction: xdr, source } })
+ Credential.serialize({ challenge, payload: { type: 'transaction', transaction: xdr }, source })
```

**New error class**
```ts
import { SettlementError } from 'stellar-mpp-sdk'
// Thrown when broadcast or confirmation fails (distinct from PaymentVerificationError)
```

**New constants**
```ts
import { CAIP2_NETWORK, CAIP2_TO_NETWORK, DEFAULT_LEDGER_CLOSE_TIME } from 'stellar-mpp-sdk'
CAIP2_NETWORK['testnet']           // → 'stellar:testnet'
CAIP2_TO_NETWORK['stellar:pubnet'] // → 'public'
```
