### PR TITLE
chore: rename package to `@stellar/mpp` for npm publication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,51 @@
+name: npm publish
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write # Required for OIDC trusted publishing (--provenance)
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm via corepack
+        run: |
+          corepack enable
+          corepack install
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm check:types
+
+      - name: Test
+        run: pnpm test -- --run
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
+
+      - name: Publish to npm
+        run: npm publish --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,14 +135,14 @@ Methods.ts (Zod schema) → client/ (create credentials) + server/ (verify crede
 
 Package.json exports allow selective imports to avoid bundling unused code:
 
-- `stellar-mpp-sdk` — root (schemas + constants + `resolveKeypair` + `Logger` type + unit conversion)
-- `stellar-mpp-sdk/charge` — charge method schema
-- `stellar-mpp-sdk/charge/client` — charge client only
-- `stellar-mpp-sdk/charge/server` — charge server only
-- `stellar-mpp-sdk/channel` — channel schema
-- `stellar-mpp-sdk/channel/client` — channel client
-- `stellar-mpp-sdk/channel/server` — channel server
-- `stellar-mpp-sdk/env` — env parsing primitives
+- `@stellar/mpp` — root (schemas + constants + `resolveKeypair` + `Logger` type + unit conversion)
+- `@stellar/mpp/charge` — charge method schema
+- `@stellar/mpp/charge/client` — charge client only
+- `@stellar/mpp/charge/server` — charge server only
+- `@stellar/mpp/channel` — channel schema
+- `@stellar/mpp/channel/client` — channel client
+- `@stellar/mpp/channel/server` — channel server
+- `@stellar/mpp/env` — env parsing primitives
 
 ### Shared Utilities Convention
 
@@ -165,7 +165,7 @@ All other `shared/` modules are strictly internal and consumed only by `charge/`
 - **Logger interface**: Matches pino's API (`debug`, `info`, `warn`, `error` methods). A `noopLogger` is used when no logger is provided.
 - **Store key naming**: Keys follow the convention `stellar:{intent}:{type}:{id}` (e.g., `stellar:charge:nonce:abc123`).
 - **Express + security headers**: Example servers use Express with helmet and rate limiting middleware. Env vars configure rate limits and trust proxy.
-- **Env parsing**: Published as `stellar-mpp-sdk/env`. Core primitives read from `process.env` with validation. Per-example `Env` classes compose these into static getters.
+- **Env parsing**: Published as `@stellar/mpp/env`. Core primitives read from `process.env` with validation. Per-example `Env` classes compose these into static getters.
 
 ### Test Setup
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ const data = await response.json()
 
 ### Exports
 
-| Path                             | Exports                                                                                                                                                                          |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Path                          | Exports                                                                                                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@stellar/mpp`                | `ChargeMethods`, `ChannelMethods`, constants (`USDC_SAC_TESTNET`, `XLM_SAC_MAINNET`, etc.), `toBaseUnits`, `fromBaseUnits`, `resolveKeypair`, `Logger` (type)                    |
 | `@stellar/mpp/charge`         | `charge` (method schema)                                                                                                                                                         |
 | `@stellar/mpp/charge/client`  | `stellar`, `charge`, `Mppx`                                                                                                                                                      |

--- a/README.md
+++ b/README.md
@@ -412,10 +412,11 @@ await close({
 
 ## Breaking changes from 0.1.0
 
-- **Import paths changed**: `@stellar/mpp/client` and `@stellar/mpp/server` are no longer valid. Use `@stellar/mpp/charge/client` and `@stellar/mpp/charge/server` instead.
+- **Package renamed**: `stellar-mpp-sdk` is now `@stellar/mpp`. All import paths change accordingly.
+- **Import paths changed**: `stellar-mpp-sdk/client` and `stellar-mpp-sdk/server` are no longer valid. Use `@stellar/mpp/charge/client` and `@stellar/mpp/charge/server` instead.
 - **Root export renamed**: `Methods` is now `ChargeMethods`.
 - **Store keys changed**: Store key format updated to `stellar:{intent}:{type}:{id}`. Existing stored data is not backwards compatible.
-- **`resolveKeypair` moved**: Now exported from the root (`@stellar/mpp`) and from `@stellar/mpp/charge/server`, no longer from `@stellar/mpp/server`.
+- **`resolveKeypair` moved**: Now exported from the root (`@stellar/mpp`) and from `@stellar/mpp/charge/server`, no longer from `stellar-mpp-sdk/server`.
 
 ## Environment variables
 
@@ -463,7 +464,7 @@ See [demo/channel-e2e-output.txt](demo/channel-e2e-output.txt) for example outpu
 ## Project structure
 
 ```
-@stellar/mpp/
+stellar-mpp-sdk/
 ├── eslint.config.mjs       # ESLint 9 flat config
 ├── .prettierrc             # Prettier configuration
 ├── Makefile                # Dev workflow targets (make help)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stellar-mpp-sdk
+# @stellar/mpp
 
 Stellar blockchain payment method for the [Machine Payments Protocol (MPP)](https://mpp.dev). Enables machine-to-machine payments using Soroban SAC token transfers on the Stellar network, with optional support for [one-way payment channels](https://github.com/stellar-experimental/one-way-channel) for high-frequency off-chain payments.
 
@@ -100,7 +100,7 @@ pnpm install
 For end users:
 
 ```bash
-npm install stellar-mpp-sdk mppx @stellar/stellar-sdk
+npm install @stellar/mpp mppx @stellar/stellar-sdk
 ```
 
 ## Quick start
@@ -108,8 +108,8 @@ npm install stellar-mpp-sdk mppx @stellar/stellar-sdk
 ### Server (charge)
 
 ```ts
-import { Mppx, stellar } from 'stellar-mpp-sdk/charge/server'
-import { USDC_SAC_TESTNET } from 'stellar-mpp-sdk'
+import { Mppx, stellar } from '@stellar/mpp/charge/server'
+import { USDC_SAC_TESTNET } from '@stellar/mpp'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY,
@@ -139,7 +139,7 @@ export async function handler(request: Request) {
 
 ```ts
 import { Keypair } from '@stellar/stellar-sdk'
-import { Mppx, stellar } from 'stellar-mpp-sdk/charge/client'
+import { Mppx, stellar } from '@stellar/mpp/charge/client'
 
 // Polyfills global fetch — 402 responses are handled automatically
 Mppx.create({
@@ -157,7 +157,7 @@ const data = await response.json()
 ### Server (channel)
 
 ```ts
-import { Mppx, stellar, Store } from 'stellar-mpp-sdk/channel/server'
+import { Mppx, stellar, Store } from '@stellar/mpp/channel/server'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY,
@@ -187,7 +187,7 @@ export async function handler(request: Request) {
 
 ```ts
 import { Keypair } from '@stellar/stellar-sdk'
-import { Mppx, stellar } from 'stellar-mpp-sdk/channel/client'
+import { Mppx, stellar } from '@stellar/mpp/channel/client'
 
 Mppx.create({
   methods: [
@@ -207,14 +207,14 @@ const data = await response.json()
 
 | Path                             | Exports                                                                                                                                                                          |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stellar-mpp-sdk`                | `ChargeMethods`, `ChannelMethods`, constants (`USDC_SAC_TESTNET`, `XLM_SAC_MAINNET`, etc.), `toBaseUnits`, `fromBaseUnits`, `resolveKeypair`, `Logger` (type)                    |
-| `stellar-mpp-sdk/charge`         | `charge` (method schema)                                                                                                                                                         |
-| `stellar-mpp-sdk/charge/client`  | `stellar`, `charge`, `Mppx`                                                                                                                                                      |
-| `stellar-mpp-sdk/charge/server`  | `stellar`, `charge`, `Mppx`, `Store`, `Expires`, `resolveKeypair`                                                                                                                |
-| `stellar-mpp-sdk/channel`        | `channel` (method schema)                                                                                                                                                        |
-| `stellar-mpp-sdk/channel/client` | `stellar`, `channel`, `Mppx`                                                                                                                                                     |
-| `stellar-mpp-sdk/channel/server` | `stellar`, `channel`, `close`, `getChannelState`, `watchChannel`, `Mppx`, `Store`, `Expires`                                                                                     |
-| `stellar-mpp-sdk/env`            | `parseRequired`, `parseOptional`, `parsePort`, `parseStellarPublicKey`, `parseStellarSecretKey`, `parseContractAddress`, `parseHexKey`, `parseCommaSeparatedList`, `parseNumber` |
+| `@stellar/mpp`                | `ChargeMethods`, `ChannelMethods`, constants (`USDC_SAC_TESTNET`, `XLM_SAC_MAINNET`, etc.), `toBaseUnits`, `fromBaseUnits`, `resolveKeypair`, `Logger` (type)                    |
+| `@stellar/mpp/charge`         | `charge` (method schema)                                                                                                                                                         |
+| `@stellar/mpp/charge/client`  | `stellar`, `charge`, `Mppx`                                                                                                                                                      |
+| `@stellar/mpp/charge/server`  | `stellar`, `charge`, `Mppx`, `Store`, `Expires`, `resolveKeypair`                                                                                                                |
+| `@stellar/mpp/channel`        | `channel` (method schema)                                                                                                                                                        |
+| `@stellar/mpp/channel/client` | `stellar`, `channel`, `Mppx`                                                                                                                                                     |
+| `@stellar/mpp/channel/server` | `stellar`, `channel`, `close`, `getChannelState`, `watchChannel`, `Mppx`, `Store`, `Expires`                                                                                     |
+| `@stellar/mpp/env`            | `parseRequired`, `parseOptional`, `parsePort`, `parseStellarPublicKey`, `parseStellarSecretKey`, `parseContractAddress`, `parseHexKey`, `parseCommaSeparatedList`, `parseNumber` |
 
 ### Server options (charge)
 
@@ -323,7 +323,7 @@ The server can decouple sequence-number management from fee payment:
 - **`feeBumpSigner`** --- optional dedicated fee payer. When set, all submitted transactions are wrapped in a `FeeBumpTransaction` signed by this key.
 
 ```ts
-import { stellar } from 'stellar-mpp-sdk/charge/server'
+import { stellar } from '@stellar/mpp/charge/server'
 
 stellar.charge({
   recipient: 'G...',
@@ -340,7 +340,7 @@ The client is automatically informed of fee sponsorship via `methodDetails.feePa
 Provide an mppx `Store` to prevent challenge reuse:
 
 ```ts
-import { Store } from 'stellar-mpp-sdk/charge/server'
+import { Store } from '@stellar/mpp/charge/server'
 
 stellar.charge({
   recipient: 'G...',
@@ -355,7 +355,7 @@ Pass a `logger` to charge or channel servers for structured debug and warning ou
 
 ```ts
 import pino from 'pino'
-import { stellar } from 'stellar-mpp-sdk/charge/server'
+import { stellar } from '@stellar/mpp/charge/server'
 
 const logger = pino({ level: 'debug' })
 
@@ -390,7 +390,7 @@ The SDK also supports opening a channel through the MPP 402 flow using the `open
 **On-chain close (server-side):**
 
 ```ts
-import { close } from 'stellar-mpp-sdk/channel/server'
+import { close } from '@stellar/mpp/channel/server'
 
 await close({
   channel: 'CABC...', // channel contract address
@@ -412,10 +412,10 @@ await close({
 
 ## Breaking changes from 0.1.0
 
-- **Import paths changed**: `stellar-mpp-sdk/client` and `stellar-mpp-sdk/server` are no longer valid. Use `stellar-mpp-sdk/charge/client` and `stellar-mpp-sdk/charge/server` instead.
+- **Import paths changed**: `@stellar/mpp/client` and `@stellar/mpp/server` are no longer valid. Use `@stellar/mpp/charge/client` and `@stellar/mpp/charge/server` instead.
 - **Root export renamed**: `Methods` is now `ChargeMethods`.
 - **Store keys changed**: Store key format updated to `stellar:{intent}:{type}:{id}`. Existing stored data is not backwards compatible.
-- **`resolveKeypair` moved**: Now exported from the root (`stellar-mpp-sdk`) and from `stellar-mpp-sdk/charge/server`, no longer from `stellar-mpp-sdk/server`.
+- **`resolveKeypair` moved**: Now exported from the root (`@stellar/mpp`) and from `@stellar/mpp/charge/server`, no longer from `@stellar/mpp/server`.
 
 ## Environment variables
 
@@ -463,7 +463,7 @@ See [demo/channel-e2e-output.txt](demo/channel-e2e-output.txt) for example outpu
 ## Project structure
 
 ```
-stellar-mpp-sdk/
+@stellar/mpp/
 ├── eslint.config.mjs       # ESLint 9 flat config
 ├── .prettierrc             # Prettier configuration
 ├── Makefile                # Dev workflow targets (make help)

--- a/demo/index.html
+++ b/demo/index.html
@@ -371,7 +371,7 @@
     </div>
 
     <p class="footer">
-      stellar-mpp-sdk &middot;
+      @stellar/mpp &middot;
       <a href="https://stellar.org" target="_blank">Stellar</a>
     </p>
 

--- a/demo/output-run.txt
+++ b/demo/output-run.txt
@@ -1,4 +1,4 @@
-sagar@sagar-K9FV9RT447-mbp stellar-mpp-sdk % ./demo/run.sh
+sagar@sagar-K9FV9RT447-mbp @stellar/mpp % ./demo/run.sh
 
 Enter your Stellar public key (recipient, starts with G):
   STELLAR_RECIPIENT=GC6ZBCI6M6PMBMRCZQMOGCUOZKFREM7P6G2NC3TD5FMYX3YLPAACQMJY

--- a/demo/output-run.txt
+++ b/demo/output-run.txt
@@ -1,4 +1,4 @@
-sagar@sagar-K9FV9RT447-mbp @stellar/mpp % ./demo/run.sh
+sagar@sagar-K9FV9RT447-mbp stellar-mpp-sdk % ./demo/run.sh
 
 Enter your Stellar public key (recipient, starts with G):
   STELLAR_RECIPIENT=GC6ZBCI6M6PMBMRCZQMOGCUOZKFREM7P6G2NC3TD5FMYX3YLPAACQMJY

--- a/docs/superpowers/plans/2026-03-27-npm-publish-rename.md
+++ b/docs/superpowers/plans/2026-03-27-npm-publish-rename.md
@@ -1,0 +1,237 @@
+# npm Package Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the package from `stellar-mpp-sdk` to `@stellar/mpp` and add npm publication metadata so it can be published publicly with `npm publish`.
+
+**Architecture:** Pure rename — no logic changes. Update `package.json` with the new name and publication metadata, then replace every string occurrence of `stellar-mpp-sdk` with `@stellar/mpp` across source, docs, and demo files.
+
+**Tech Stack:** Node.js / TypeScript, pnpm, npm registry.
+
+---
+
+## Files Modified
+
+| File                                | Change                                                |
+| ----------------------------------- | ----------------------------------------------------- |
+| `package.json`                      | Rename, add `publishConfig`, `repository`, `keywords` |
+| `README.md`                         | All `stellar-mpp-sdk` occurrences → `@stellar/mpp`    |
+| `CLAUDE.md`                         | All `stellar-mpp-sdk` occurrences → `@stellar/mpp`    |
+| `sdk/src/charge/client/Charge.ts`   | JSDoc comment import example                          |
+| `sdk/src/channel/client/Channel.ts` | JSDoc comment import example                          |
+| `sdk/src/channel/server/Channel.ts` | JSDoc comment import example                          |
+| `sdk/src/channel/server/State.ts`   | JSDoc comment import example                          |
+| `sdk/src/channel/server/Watcher.ts` | JSDoc comment import example                          |
+| `demo/index.html`                   | Cosmetic branding text                                |
+| `demo/output-run.txt`               | Terminal prompt in sample output                      |
+
+---
+
+### Task 1: Update `package.json`
+
+**Files:**
+
+- Modify: `package.json`
+
+- [ ] **Step 1: Edit `package.json`**
+
+  Apply the following changes:
+
+  ```json
+  {
+    "name": "@stellar/mpp",
+    "publishConfig": {
+      "access": "public"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/stellar/stellar-mpp-sdk.git"
+    },
+    "keywords": [
+      "stellar",
+      "blockchain",
+      "payments",
+      "mpp",
+      "machine-payments",
+      "soroban",
+      "payment-channels",
+      "typescript",
+      "sdk",
+      "402",
+      "agentic-payments",
+      "mppx"
+    ]
+  }
+  ```
+
+  Place `publishConfig` and `repository` after `"license"` and before `"dependencies"`. Place `keywords` after `"repository"`.
+
+- [ ] **Step 2: Verify `package.json` parses correctly**
+
+  Run: `node -e "const p = require('./package.json'); console.log(p.name, p.publishConfig)"`
+  Expected: `@stellar/mpp { access: 'public' }`
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add package.json
+  git commit -m "chore: rename package to @stellar/mpp, add npm publication metadata"
+  ```
+
+---
+
+### Task 2: Update `README.md`
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Replace all occurrences in README.md**
+
+  Replace every instance of `stellar-mpp-sdk` with `@stellar/mpp` throughout the file. This includes:
+  - Install command (line ~103): `npm install stellar-mpp-sdk mppx @stellar/stellar-sdk`
+  - All import examples in code blocks (e.g. `from 'stellar-mpp-sdk/charge/server'`)
+  - The Exports table (lines ~208–217)
+  - The "Breaking changes from 0.1.0" section prose references (lines ~415–418)
+
+  Verify count before and after:
+
+  ```bash
+  grep -c 'stellar-mpp-sdk' README.md   # should be 0 after edit
+  grep -c '@stellar/mpp' README.md       # count should match what was replaced
+  ```
+
+- [ ] **Step 2: Spot-check a few key lines**
+
+  Confirm these are correct after editing:
+  - Install: `npm install @stellar/mpp mppx @stellar/stellar-sdk`
+  - Import example: `import { Mppx, stellar } from '@stellar/mpp/charge/server'`
+  - Exports table row: `\`@stellar/mpp\`` (root entry)
+  - Breaking changes prose: `Use \`@stellar/mpp/charge/client\` and \`@stellar/mpp/charge/server\``
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add README.md
+  git commit -m "docs: update README imports and install command to @stellar/mpp"
+  ```
+
+---
+
+### Task 3: Update `CLAUDE.md`
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Replace all occurrences in CLAUDE.md**
+
+  Replace every instance of `stellar-mpp-sdk` with `@stellar/mpp` in `CLAUDE.md`.
+
+  Verify:
+
+  ```bash
+  grep -c 'stellar-mpp-sdk' CLAUDE.md   # should be 0 after edit
+  ```
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  git add CLAUDE.md
+  git commit -m "docs: update CLAUDE.md import references to @stellar/mpp"
+  ```
+
+---
+
+### Task 4: Update JSDoc comments in `sdk/src/`
+
+**Files:**
+
+- Modify: `sdk/src/charge/client/Charge.ts`
+- Modify: `sdk/src/channel/client/Channel.ts`
+- Modify: `sdk/src/channel/server/Channel.ts`
+- Modify: `sdk/src/channel/server/State.ts`
+- Modify: `sdk/src/channel/server/Watcher.ts`
+
+- [ ] **Step 1: Replace occurrences in all 5 source files**
+
+  Each file has exactly one JSDoc comment line containing `stellar-mpp-sdk` as a package name prefix (the subpath varies per file, e.g. `'stellar-mpp-sdk/channel/server'`, `'stellar-mpp-sdk/client'`).
+  Replace the package name prefix in all five files:
+
+  Replace `stellar-mpp-sdk` with `@stellar/mpp` in each file.
+
+  Verify:
+
+  ```bash
+  grep -r 'stellar-mpp-sdk' sdk/src/   # should return nothing
+  ```
+
+- [ ] **Step 2: Ensure TypeScript still compiles**
+
+  Run: `pnpm run check:types`
+  Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add sdk/src/charge/client/Charge.ts sdk/src/channel/client/Channel.ts \
+          sdk/src/channel/server/Channel.ts sdk/src/channel/server/State.ts \
+          sdk/src/channel/server/Watcher.ts
+  git commit -m "docs: update JSDoc import examples to @stellar/mpp"
+  ```
+
+---
+
+### Task 5: Update demo files
+
+**Files:**
+
+- Modify: `demo/index.html`
+- Modify: `demo/output-run.txt`
+
+- [ ] **Step 1: Replace occurrences in demo files**
+  - `demo/index.html` line ~374: `stellar-mpp-sdk &middot;` → `@stellar/mpp &middot;`
+  - `demo/output-run.txt` line 1: `stellar-mpp-sdk %` → `@stellar/mpp %`
+
+  Verify:
+
+  ```bash
+  grep -r 'stellar-mpp-sdk' demo/   # should return nothing
+  ```
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  git add demo/index.html demo/output-run.txt
+  git commit -m "chore: update demo files to @stellar/mpp"
+  ```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Confirm zero remaining occurrences**
+
+  ```bash
+  grep -r 'stellar-mpp-sdk' . --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git --exclude-dir=docs
+  ```
+
+  Expected: no output.
+
+- [ ] **Step 2: Run full quality pipeline**
+
+  ```bash
+  pnpm test -- --run
+  pnpm run check:types
+  pnpm run build
+  ```
+
+  Expected: all pass with no errors.
+
+- [ ] **Step 3: Verify package contents**
+
+  ```bash
+  npm pack --dry-run
+  ```
+
+  Expected: output shows `@stellar/mpp` as the package name and lists only `dist/` files.

--- a/docs/superpowers/specs/2026-03-27-npm-publish-rename-design.md
+++ b/docs/superpowers/specs/2026-03-27-npm-publish-rename-design.md
@@ -1,0 +1,43 @@
+# Design: Rename package to `@stellar/mpp` for npm publication
+
+**Date:** 2026-03-27
+**Status:** Approved
+
+## Goal
+
+Prepare the repository for public npm publication as `@stellar/mpp`, replacing the current internal name `stellar-mpp-sdk`.
+
+## package.json changes
+
+| Field           | Before              | After                                                                                                                                                     |
+| --------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`          | `"stellar-mpp-sdk"` | `"@stellar/mpp"`                                                                                                                                          |
+| `publishConfig` | _(absent)_          | `{"access": "public"}`                                                                                                                                    |
+| `repository`    | _(absent)_          | `{"type": "git", "url": "git+https://github.com/stellar/stellar-mpp-sdk.git"}`                                                                            |
+| `keywords`      | _(absent)_          | `["stellar", "blockchain", "payments", "mpp", "machine-payments", "soroban", "payment-channels", "typescript", "sdk", "402", "agentic-payments", "mppx"]` |
+
+`publishConfig.access: "public"` is required — scoped npm packages default to private and will be rejected without it.
+
+No `homepage` field is added.
+
+## Reference updates
+
+All occurrences of `stellar-mpp-sdk` renamed to `@stellar/mpp` in:
+
+| File                                | Nature of change                                                                                            |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `README.md`                         | Install command, all import examples in code blocks, and prose references in the "Breaking changes" section |
+| `CLAUDE.md`                         | Module map table, subpath exports section, import examples                                                  |
+| `sdk/src/charge/client/Charge.ts`   | JSDoc comment import example                                                                                |
+| `sdk/src/channel/client/Channel.ts` | JSDoc comment import example                                                                                |
+| `sdk/src/channel/server/Channel.ts` | JSDoc comment import example                                                                                |
+| `sdk/src/channel/server/State.ts`   | JSDoc comment import example                                                                                |
+| `sdk/src/channel/server/Watcher.ts` | JSDoc comment import example                                                                                |
+| `demo/index.html`                   | Cosmetic branding text                                                                                      |
+| `demo/output-run.txt`               | Terminal prompt in sample output                                                                            |
+
+## Out of scope
+
+- No changes to version, description, engines, exports, files, scripts, or dependencies
+- No changes to source logic
+- No `.npmignore` needed (`files: ["dist"]` already limits what gets published)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stellar-mpp-sdk",
+  "name": "@stellar/mpp",
   "version": "0.2.0",
   "description": "Stellar blockchain payment method for the Machine Payments Protocol (MPP)",
   "type": "module",
@@ -84,6 +84,27 @@
     "vitest": "^4.1.2"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stellar/stellar-mpp-sdk.git"
+  },
+  "keywords": [
+    "stellar",
+    "blockchain",
+    "payments",
+    "mpp",
+    "machine-payments",
+    "soroban",
+    "payment-channels",
+    "typescript",
+    "sdk",
+    "402",
+    "agentic-payments",
+    "mppx"
+  ],
   "dependencies": {
     "zod": "^4.3.6"
   }

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -23,7 +23,7 @@ import { channel as ChannelMethod } from '../Methods.js'
  * ```ts
  * import { Keypair } from '@stellar/stellar-sdk'
  * import { Mppx } from 'mppx/client'
- * import { stellar } from 'stellar-mpp-sdk/channel/client'
+ * import { stellar } from '@stellar/mpp/channel/client'
  *
  * Mppx.create({
  *   methods: [

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -44,7 +44,7 @@ import { getChannelState, type ChannelState } from './State.js'
  *
  * @example
  * ```ts
- * import { stellar } from 'stellar-mpp-sdk/channel/server'
+ * import { stellar } from '@stellar/mpp/channel/server'
  * import { Mppx } from 'mppx/server'
  *
  * const mppx = Mppx.create({

--- a/sdk/src/channel/server/State.ts
+++ b/sdk/src/channel/server/State.ts
@@ -46,7 +46,7 @@ export type ChannelState = {
  *
  * @example
  * ```ts
- * import { getChannelState } from 'stellar-mpp-sdk/channel/server'
+ * import { getChannelState } from '@stellar/mpp/channel/server'
  *
  * const state = await getChannelState({
  *   channel: 'CABC...',

--- a/sdk/src/channel/server/Watcher.ts
+++ b/sdk/src/channel/server/Watcher.ts
@@ -25,7 +25,7 @@ const KNOWN_TOPICS = new Set(['close', 'close_start', 'refund', 'top_up'])
  *
  * @example
  * ```ts
- * import { watchChannel } from 'stellar-mpp-sdk/channel/server'
+ * import { watchChannel } from '@stellar/mpp/channel/server'
  *
  * const stop = watchChannel({
  *   channel: 'CABC...',

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -44,7 +44,7 @@ import {
  * ```ts
  * import { Keypair } from '@stellar/stellar-sdk'
  * import { Mppx } from 'mppx/client'
- * import { stellar } from '@stellar/mpp/client'
+ * import { stellar } from '@stellar/mpp/charge/client'
  *
  * Mppx.create({
  *   methods: [

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -44,7 +44,7 @@ import {
  * ```ts
  * import { Keypair } from '@stellar/stellar-sdk'
  * import { Mppx } from 'mppx/client'
- * import { stellar } from 'stellar-mpp-sdk/client'
+ * import { stellar } from '@stellar/mpp/client'
  *
  * Mppx.create({
  *   methods: [


### PR DESCRIPTION
## What

- Rename `package.json` `name` from `stellar-mpp-sdk` to `@stellar/mpp`
- Add `publishConfig: { access: "public" }` — required for scoped packages to be publicly installable on npm
- Add `repository` (pointing to `github.com/stellar/stellar-mpp-sdk`) and `keywords` fields
- Update all `stellar-mpp-sdk` references across README, CLAUDE.md, JSDoc comments, and demo files
- Fix pre-existing JSDoc typo in `Charge.ts`: `@stellar/mpp/client` → `@stellar/mpp/charge/client`

## Why

The package is moving to the `@stellar` npm scope to reflect its official standing in the Stellar ecosystem. The repository is also moving from `stellar-experimental` to `stellar` on GitHub. This PR makes the package publishable as `@stellar/mpp` via `npm publish`.

## Example

**Before:**

```bash
npm install stellar-mpp-sdk mppx @stellar/stellar-sdk
```

```ts
import { stellar } from 'stellar-mpp-sdk/charge/server'
import { USDC_SAC_TESTNET } from 'stellar-mpp-sdk'
```

**After:**

```bash
npm install @stellar/mpp mppx @stellar/stellar-sdk
```

```ts
import { stellar } from '@stellar/mpp/charge/server'
import { USDC_SAC_TESTNET } from '@stellar/mpp'
```
