### PR TITLE
docs: rewrite Install section for npm package consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ corepack enable
 npm install @stellar/mpp @stellar/stellar-sdk mppx
 ```
 
-`@stellar/stellar-sdk` and `mppx` are peer dependencies — you must install them alongside the SDK.
+`@stellar/stellar-sdk` and `mppx` are peer dependencies of `@stellar/mpp` — you must install compatible versions alongside it.
 
 Only import the subpath you need to keep your bundle small:
 
-```ts
+```
+# Pick the import for your use case:
 import { stellar } from '@stellar/mpp/charge/server' // charge server only
 import { stellar } from '@stellar/mpp/charge/client' // charge client only
 import { stellar } from '@stellar/mpp/channel/server' // channel server only

--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ npm install @stellar/mpp @stellar/stellar-sdk mppx
 Only import the subpath you need to keep your bundle small:
 
 ```ts
-import { stellar } from '@stellar/mpp/charge/server'  // charge server only
-import { stellar } from '@stellar/mpp/charge/client'  // charge client only
+import { stellar } from '@stellar/mpp/charge/server' // charge server only
+import { stellar } from '@stellar/mpp/charge/client' // charge client only
 import { stellar } from '@stellar/mpp/channel/server' // channel server only
 import { stellar } from '@stellar/mpp/channel/client' // channel client only
-import { parsePort } from '@stellar/mpp/env'          // env helpers only
-import { USDC_SAC_TESTNET } from '@stellar/mpp'       // constants, schemas, error types
+import { parsePort } from '@stellar/mpp/env' // env helpers only
+import { USDC_SAC_TESTNET } from '@stellar/mpp' // constants, schemas, error types
 ```
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -93,14 +93,20 @@ corepack enable
 ## Install
 
 ```bash
-corepack enable
-pnpm install
+npm install @stellar/mpp @stellar/stellar-sdk mppx
 ```
 
-For end users:
+`@stellar/stellar-sdk` and `mppx` are peer dependencies — you must install them alongside the SDK.
 
-```bash
-npm install @stellar/mpp mppx @stellar/stellar-sdk
+Only import the subpath you need to keep your bundle small:
+
+```ts
+import { stellar } from '@stellar/mpp/charge/server'  // charge server only
+import { stellar } from '@stellar/mpp/charge/client'  // charge client only
+import { stellar } from '@stellar/mpp/channel/server' // channel server only
+import { stellar } from '@stellar/mpp/channel/client' // channel client only
+import { parsePort } from '@stellar/mpp/env'          // env helpers only
+import { USDC_SAC_TESTNET } from '@stellar/mpp'       // constants, schemas, error types
 ```
 
 ## Quick start
@@ -468,6 +474,11 @@ Source lives in `sdk/src/` with colocated tests (`*.test.ts`). Each payment mode
 ## Development
 
 ```bash
+corepack enable       # Enable pnpm via corepack
+pnpm install          # Install deps (also compiles TypeScript via prepare script)
+```
+
+```bash
 make help       # Show all available commands
 make check      # Run full quality pipeline (format, lint, typecheck, test, build)
 make test       # Run tests once
@@ -477,7 +488,6 @@ make test-watch # Run tests in watch mode
 See the [Makefile](Makefile) for all targets.
 
 ```bash
-pnpm install          # Install deps
 pnpm run build        # Compile TypeScript
 pnpm run check:types  # Type-check without emitting
 pnpm run lint         # Run ESLint


### PR DESCRIPTION
## What
- Rewrote the Install section to focus on end users consuming `@stellar/mpp` from npm
- Added peer dependency callout and subpath import examples showing all available entry points
- Moved contributor setup (`corepack enable` + `pnpm install`) into the Development section where it belongs

## Why
The Install section previously mixed contributor setup with end-user installation, making it unclear how to get started as a consumer of the published npm package. Now that `@stellar/mpp` is published, the Install section should lead with the npm install command and show available subpath imports.