### PR TITLE
chore: add CHANGELOG and release structure for v0.2.x

### DIFF
--- a/.claude/skills/e2e-check/SKILL.md
+++ b/.claude/skills/e2e-check/SKILL.md
@@ -101,6 +101,18 @@ Full lifecycle: deploy contract -> 2 off-chain payments -> on-chain close -> bal
 
 **Pass:** Script completes with `Channel balance after close: 0` and exit code 0.
 
+## Check 6: CHANGELOG Entry
+
+Every PR must add a line to `CHANGELOG.md` under the current unreleased version section. Each entry must link to its PR using the format:
+
+```
+- Description of the change [#PR_NUMBER](https://github.com/stellar/stellar-mpp-sdk/pull/PR_NUMBER)
+```
+
+**Pass:** The diff includes a CHANGELOG.md addition with a PR link in the correct format.
+
+**Fail:** No CHANGELOG entry, or entry missing the `[#N](url)` PR link.
+
 ## Reporting
 
 After running all checks, report:

--- a/.claude/skills/e2e-check/SKILL.md
+++ b/.claude/skills/e2e-check/SKILL.md
@@ -103,7 +103,7 @@ Full lifecycle: deploy contract -> 2 off-chain payments -> on-chain close -> bal
 
 ## Check 6: CHANGELOG Entry
 
-Every PR must add a line to `CHANGELOG.md` under the current unreleased version section. Each entry must link to its PR using the format:
+Every PR must add a line to `CHANGELOG.md` under the `## [Unreleased]` heading. Each entry must link to its PR using the format:
 
 ```
 - Description of the change [#PR_NUMBER](https://github.com/stellar/stellar-mpp-sdk/pull/PR_NUMBER)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.2.1] - 2026-03-30
 
 ### Fixed
@@ -27,5 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Env parsing primitives for Stellar-aware configuration
 - Shared utilities: fee bump wrapping, transaction polling with backoff, Soroban simulation, unit conversion, keypair resolution
 
+[Unreleased]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/stellar/stellar-mpp-sdk/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.1] - 2026-03-30
+
+### Fixed
+
+- Bump `path-to-regexp` (8.3.0 → 8.4.0), `picomatch` (4.0.3 → 4.0.4), and `yaml` (2.8.2 → 2.8.3) to address security vulnerabilities (CVE-2026-4926, CVE-2026-4923, CVE-2026-33671, CVE-2026-33672)
+
+### Changed
+
+- Rewrote the Install section in the README to focus on npm package consumers, with peer dependency callout and subpath import examples
+
+## [0.2.0] - 2026-03-30
+
+### Added
+
+- Initial release of `@stellar/mpp` — a TypeScript SDK for Stellar blockchain payment methods in the Machine Payments Protocol (MPP)
+- **Charge module**: one-time on-chain SAC token transfers with pull (transaction credential) and push (hash credential) modes, following the [draft-stellar-charge-00](https://paymentauth.org/draft-stellar-charge-00) specification
+- **Channel module**: off-chain payment commitments via one-way payment channel contracts with batch settlement on close (session spec in progress)
+- Subpath exports for selective imports (`@stellar/mpp/charge/client`, `@stellar/mpp/charge/server`, `@stellar/mpp/channel/client`, `@stellar/mpp/channel/server`, `@stellar/mpp/env`)
+- Env parsing primitives for Stellar-aware configuration
+- Shared utilities: fee bump wrapping, transaction polling with backoff, Soroban simulation, unit conversion, keypair resolution
+
+[0.2.1]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/stellar/stellar-mpp-sdk/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rewrote the Install section in the README to focus on npm package consumers, with peer dependency callout and subpath import examples [#29](https://github.com/stellar/stellar-mpp-sdk/pull/29)
+- Add CHANGELOG and release structure for v0.2.x [#31](https://github.com/stellar/stellar-mpp-sdk/pull/31)
 
 ## [0.2.0] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bump `path-to-regexp` (8.3.0 → 8.4.0), `picomatch` (4.0.3 → 4.0.4), and `yaml` (2.8.2 → 2.8.3) to address security vulnerabilities (CVE-2026-4926, CVE-2026-4923, CVE-2026-33671, CVE-2026-33672)
+- Bump `path-to-regexp` (8.3.0 → 8.4.0), `picomatch` (4.0.3 → 4.0.4), and `yaml` (2.8.2 → 2.8.3) to address security vulnerabilities (CVE-2026-4926, CVE-2026-4923, CVE-2026-33671, CVE-2026-33672) [#28](https://github.com/stellar/stellar-mpp-sdk/pull/28)
 
 ### Changed
 
-- Rewrote the Install section in the README to focus on npm package consumers, with peer dependency callout and subpath import examples
+- Rewrote the Install section in the README to focus on npm package consumers, with peer dependency callout and subpath import examples [#29](https://github.com/stellar/stellar-mpp-sdk/pull/29)
 
 ## [0.2.0] - 2026-03-30
 


### PR DESCRIPTION
## What
- Add `CHANGELOG.md` covering v0.2.0 (initial release) and v0.2.1 (security dep bumps + docs rewrite)
- v0.2.1 entries include PR links in `[#N](url)` format as the new standard
- Add Check 6 to the e2e-check skill requiring every PR to include a changelog entry with a PR link

## Why
The project had no changelog. As we prepare the v0.2.1 release, we need a structured changelog that follows Keep a Changelog conventions, with traceable PR links starting from this release onward.