### PR TITLE
refactor: spec-compliant charge feePayer and CAIP-2 NetworkId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-31
+
+### Changed
+
+- Align fee-bump transaction handling with the spec and restructure server signer configuration (`feePayer`) to match cross-chain conventions [#33](https://github.com/stellar/stellar-mpp-sdk/pull/33)
+
 ## [0.2.1] - 2026-03-30
 
 ### Fixed
@@ -29,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Env parsing primitives for Stellar-aware configuration
 - Shared utilities: fee bump wrapping, transaction polling with backoff, Soroban simulation, unit conversion, keypair resolution
 
-[Unreleased]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/stellar/stellar-mpp-sdk/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ const data = await response.json()
 stellar.charge({
   recipient: string,              // Stellar public key (G...) or contract (C...)
   currency: string,               // SAC contract address
-  network?: 'testnet' | 'public', // default: 'testnet'
+  network?: 'stellar:testnet' | 'stellar:pubnet', // default: 'stellar:testnet'
   decimals?: number,              // default: 7
   rpcUrl?: string,                // custom Soroban RPC URL
   feePayer?: {                     // server-sponsored fee configuration
@@ -270,7 +270,7 @@ stellar.charge({
 stellar.channel({
   channel: string,                // on-chain channel contract address (C...)
   commitmentKey: string | Keypair,// ed25519 public key for verifying commitments
-  network?: 'testnet' | 'public', // default: 'testnet'
+  network?: 'stellar:testnet' | 'stellar:pubnet', // default: 'stellar:testnet'
   decimals?: number,              // default: 7
   rpcUrl?: string,                // custom Soroban RPC URL
   sourceAccount?: string,         // funded G... address for simulations

--- a/README.md
+++ b/README.md
@@ -232,8 +232,10 @@ stellar.charge({
   network?: 'testnet' | 'public', // default: 'testnet'
   decimals?: number,              // default: 7
   rpcUrl?: string,                // custom Soroban RPC URL
-  signer?: Keypair | string,      // source account for sponsored tx signing
-  feeBumpSigner?: Keypair | string, // wraps all txs in FeeBumpTransaction
+  feePayer?: {                     // server-sponsored fee configuration
+    envelopeSigner: Keypair | string,   // source account + envelope signer
+    feeBumpSigner?: Keypair | string,   // wraps sponsored tx in FeeBumpTransaction
+  },
   store?: Store.Store,            // replay protection
   maxFeeBumpStroops?: number,     // max fee bump in stroops (default: 10,000,000)
   pollMaxAttempts?: number,       // max polling attempts (default: 30)
@@ -322,25 +324,53 @@ The `onProgress` callback receives events at each stage:
 | `signing`   | ---                                     | Before signing commitment |
 | `signed`    | `cumulativeAmount`                      | Commitment signed         |
 
-### Fee sponsorship
+### Fee sponsorship and fee bumping
 
-The server can decouple sequence-number management from fee payment:
+The `feePayer` option controls server-sponsored fees per the [Stellar Charge spec](https://paymentauth.org/draft-stellar-charge-00). It groups two keypairs that operate at different stages of the sponsored transaction lifecycle:
 
-- **`signer`** --- keypair providing the source account and sequence number for sponsored transactions.
-- **`feeBumpSigner`** --- optional dedicated fee payer. When set, all submitted transactions are wrapped in a `FeeBumpTransaction` signed by this key.
+#### `feePayer.envelopeSigner` — transaction sponsor
+
+Provides the source account, sequence number, and envelope signature for sponsored transactions. The challenge includes `methodDetails.feePayer: true`, which tells the client:
+
+- **Pull mode is required** — the client must send signed XDR for the server to broadcast (push mode is rejected).
+- The client builds the transaction with an **all-zeros placeholder source** and signs only the Soroban authorization entries (not the envelope). The server rebuilds the transaction with its own account and signs the envelope.
+
+Without `feePayer`, both push and pull modes are available and the client builds and signs the full transaction. Per the spec, unsponsored transactions are submitted as-is — the server MUST NOT modify them.
+
+#### `feePayer.feeBumpSigner` — fee bump wrapper (sponsored path only)
+
+When set, the server wraps the **sponsored** transaction in a [`FeeBumpTransaction`](https://developers.stellar.org/docs/learn/glossary#fee-bump-transaction) before broadcasting. This is a post-verification step that applies after the server rebuilds and signs the transaction.
+
+`feeBumpSigner` is nested inside `feePayer` because it only applies to the sponsored path. The spec requires unsponsored transactions to be submitted without modification, so fee bumping an unsponsored transaction would violate the spec.
 
 ```ts
 import { stellar } from '@stellar/mpp/charge/server'
 
+// Sponsored with fee bumping
 stellar.charge({
   recipient: 'G...',
   currency: USDC_SAC_TESTNET,
-  signer: Keypair.fromSecret('S...'), // source account
-  feeBumpSigner: Keypair.fromSecret('S...'), // pays all fees
+  feePayer: {
+    envelopeSigner: Keypair.fromSecret('S...'), // source account + envelope sig
+    feeBumpSigner: Keypair.fromSecret('S...'), // wraps in FeeBumpTransaction
+  },
+})
+
+// Sponsored without fee bumping
+stellar.charge({
+  recipient: 'G...',
+  currency: USDC_SAC_TESTNET,
+  feePayer: {
+    envelopeSigner: Keypair.fromSecret('S...'),
+  },
+})
+
+// Unsponsored (no feePayer — both push and pull available)
+stellar.charge({
+  recipient: 'G...',
+  currency: USDC_SAC_TESTNET,
 })
 ```
-
-The client is automatically informed of fee sponsorship via `methodDetails.feePayer` in the challenge.
 
 ### Replay protection
 

--- a/examples/channel-close.ts
+++ b/examples/channel-close.ts
@@ -30,7 +30,7 @@ const CHANNEL_CONTRACT = parseContractAddress('CHANNEL_CONTRACT')
 const COMMITMENT_SECRET = parseHexKey('COMMITMENT_SECRET')
 const CLOSE_SECRET = parseStellarSecretKey('CLOSE_SECRET')
 const AMOUNT = BigInt(parseOptional('AMOUNT', '2000000')!)
-const NETWORK = 'testnet' as const
+const NETWORK = 'stellar:testnet' as const
 
 const commitmentKey = Keypair.fromRawEd25519Seed(Buffer.from(COMMITMENT_SECRET, 'hex'))
 const closeKey = Keypair.fromSecret(CLOSE_SECRET)

--- a/examples/channel-server.ts
+++ b/examples/channel-server.ts
@@ -48,7 +48,7 @@ const mppx = Mppx.create({
       commitmentKey: commitmentPublicKeyG,
       sourceAccount: Env.sourceAccount,
       store,
-      network: 'testnet',
+      network: 'stellar:testnet',
       logger,
     }),
   ],

--- a/examples/charge-server.ts
+++ b/examples/charge-server.ts
@@ -42,7 +42,7 @@ const mppx = Mppx.create({
     stellar.charge({
       recipient: Env.stellarRecipient,
       currency: USDC_SAC_TESTNET,
-      network: 'testnet',
+      network: 'stellar:testnet',
       store: Store.memory(),
       logger,
     }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/mpp",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Stellar blockchain payment method for the Machine Payments Protocol (MPP)",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/sdk/src/channel/Methods.test.ts
+++ b/sdk/src/channel/Methods.test.ts
@@ -38,12 +38,12 @@ describe('channel method schema', () => {
       channel: 'CABC123',
       methodDetails: {
         reference: 'ref-001',
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: '5000000',
       },
     })
     expect(result.methodDetails?.reference).toBe('ref-001')
-    expect(result.methodDetails?.network).toBe('testnet')
+    expect(result.methodDetails?.network).toBe('stellar:testnet')
     expect(result.methodDetails?.cumulativeAmount).toBe('5000000')
   })
 

--- a/sdk/src/channel/client/Channel.test.ts
+++ b/sdk/src/channel/client/Channel.test.ts
@@ -291,3 +291,35 @@ describe('channel createCredential open action', () => {
     expect(decoded.payload.amount).toBe('5000000')
   })
 })
+
+describe('network validation', () => {
+  it('throws on unsupported network identifier', async () => {
+    const method = channel({ commitmentKey: TEST_KEYPAIR })
+    const challenge = mockChallenge({
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'stellar:futurenet',
+        cumulativeAmount: '0',
+      },
+    })
+
+    await expect(
+      method.createCredential({ challenge: challenge as any, context: {} as any }),
+    ).rejects.toThrow('Unsupported Stellar network identifier: "stellar:futurenet"')
+  })
+
+  it('throws on old-style network shorthand', async () => {
+    const method = channel({ commitmentKey: TEST_KEYPAIR })
+    const challenge = mockChallenge({
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'testnet',
+        cumulativeAmount: '0',
+      },
+    })
+
+    await expect(
+      method.createCredential({ challenge: challenge as any, context: {} as any }),
+    ).rejects.toThrow('Unsupported Stellar network identifier: "testnet"')
+  })
+})

--- a/sdk/src/channel/client/Channel.test.ts
+++ b/sdk/src/channel/client/Channel.test.ts
@@ -43,7 +43,7 @@ function mockChallenge(overrides: Record<string, unknown> = {}) {
       channel: CHANNEL_ADDRESS,
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: '0',
       },
       ...overrides,
@@ -129,7 +129,7 @@ describe('channel createCredential voucher', () => {
       amount: '500000',
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: '2000000', // previous cumulative
       },
     })
@@ -272,7 +272,7 @@ describe('channel createCredential open action', () => {
       amount: '5000000',
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: '0', // no previous cumulative for open
       },
     })

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -1,16 +1,11 @@
 import { Contract, Keypair, TransactionBuilder, nativeToScVal, rpc } from '@stellar/stellar-sdk'
 import { Credential, Method } from 'mppx'
 import { z } from 'zod/mini'
-import {
-  DEFAULT_FEE,
-  NETWORK_PASSPHRASE,
-  SOROBAN_RPC_URLS,
-  STELLAR_TESTNET,
-  type NetworkId,
-} from '../../constants.js'
+import { DEFAULT_FEE, NETWORK_PASSPHRASE, SOROBAN_RPC_URLS } from '../../constants.js'
 import { DEFAULT_SIMULATION_TIMEOUT_MS } from '../../shared/defaults.js'
 import { StellarMppError } from '../../shared/errors.js'
 import { simulateCall } from '../../shared/simulate.js'
+import { resolveNetworkId } from '../../shared/validation.js'
 import { channel as ChannelMethod } from '../Methods.js'
 
 /**
@@ -63,7 +58,7 @@ export function channel(parameters: channel.Parameters) {
     async createCredential({ challenge, context }) {
       const { request } = challenge
       const { amount, channel: channelAddress } = request
-      const network: NetworkId = (request.methodDetails?.network as NetworkId) ?? STELLAR_TESTNET
+      const network = resolveNetworkId(request.methodDetails?.network)
 
       // The server tells us the cumulative amount via methodDetails,
       // or the caller can override via context.

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_FEE,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
+  STELLAR_TESTNET,
   type NetworkId,
 } from '../../constants.js'
 import { DEFAULT_SIMULATION_TIMEOUT_MS } from '../../shared/defaults.js'
@@ -62,7 +63,7 @@ export function channel(parameters: channel.Parameters) {
     async createCredential({ challenge, context }) {
       const { request } = challenge
       const { amount, channel: channelAddress } = request
-      const network: NetworkId = (request.methodDetails?.network as NetworkId) ?? 'testnet'
+      const network: NetworkId = (request.methodDetails?.network as NetworkId) ?? STELLAR_TESTNET
 
       // The server tells us the cumulative amount via methodDetails,
       // or the caller can override via context.

--- a/sdk/src/channel/integration.test.ts
+++ b/sdk/src/channel/integration.test.ts
@@ -18,7 +18,7 @@ function mockChallenge(overrides: Record<string, unknown> = {}) {
       channel: CHANNEL_ADDRESS,
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: '0',
       },
       ...overrides,

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -77,7 +77,7 @@ function makeCredential(opts: {
       channel: CHANNEL_ADDRESS,
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: opts.cumulativeAmount ?? '0',
       },
     },
@@ -112,7 +112,7 @@ function makeSignedCredential(opts: {
       channel: CHANNEL_ADDRESS,
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: opts.previousCumulative ?? '0',
       },
     },
@@ -156,7 +156,7 @@ function makeOpenCredential(opts: {
       channel: CHANNEL_ADDRESS,
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: '0',
       },
     },
@@ -191,7 +191,7 @@ function makeSignedOpenCredential(opts: {
       channel: CHANNEL_ADDRESS,
       methodDetails: {
         reference: crypto.randomUUID(),
-        network: 'testnet',
+        network: 'stellar:testnet',
         cumulativeAmount: '0',
       },
     },
@@ -238,7 +238,7 @@ describe('stellar server channel', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
-      network: 'public',
+      network: 'stellar:pubnet',
     })
     expect(method.name).toBe('stellar')
   })
@@ -973,7 +973,7 @@ describe('close()', () => {
       amount: 5000000n,
       signature,
       signer,
-      network: 'testnet',
+      network: 'stellar:testnet',
     })
 
     expect(hash).toBe('close-tx-hash')
@@ -994,7 +994,7 @@ describe('close()', () => {
         amount: 5000000n,
         signature,
         signer,
-        network: 'testnet',
+        network: 'stellar:testnet',
       }),
     ).rejects.toThrow('sendTransaction returned ERROR')
   })
@@ -1013,7 +1013,7 @@ describe('close()', () => {
         amount: 5000000n,
         signature,
         signer,
-        network: 'testnet',
+        network: 'stellar:testnet',
       }),
     ).rejects.toThrow('sendTransaction returned DUPLICATE')
   })
@@ -1033,7 +1033,7 @@ describe('close()', () => {
         amount: 5000000n,
         signature,
         signer,
-        network: 'testnet',
+        network: 'stellar:testnet',
       }),
     ).rejects.toThrow(/failed/i)
   })

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
+  STELLAR_TESTNET,
   type NetworkId,
 } from '../../constants.js'
 import {
@@ -69,7 +70,7 @@ export function channel(parameters: channel.Parameters) {
     decimals = DEFAULT_DECIMALS,
     feeBumpSigner: feeBumpSignerParam,
     maxFeeBumpStroops = DEFAULT_MAX_FEE_BUMP_STROOPS,
-    network = 'testnet',
+    network = STELLAR_TESTNET,
     onDisputeDetected,
     pollDelayMs = DEFAULT_POLL_DELAY_MS,
     pollMaxAttempts = DEFAULT_POLL_MAX_ATTEMPTS,
@@ -725,7 +726,7 @@ export async function close(parameters: {
     signature,
     signer,
     feeBumpSigner,
-    network = 'testnet',
+    network = STELLAR_TESTNET,
     rpcUrl,
     maxFeeBumpStroops = DEFAULT_MAX_FEE_BUMP_STROOPS,
     pollMaxAttempts = DEFAULT_POLL_MAX_ATTEMPTS,
@@ -826,7 +827,7 @@ export declare namespace channel {
     decimals?: number
     /** Maximum fee bump in stroops. @default 10_000_000 */
     maxFeeBumpStroops?: number
-    /** Stellar network. @default 'testnet' */
+    /** Stellar network. @default 'stellar:testnet' */
     network?: NetworkId
     /**
      * Called when a dispute is detected on-chain (close_start has been called).

--- a/sdk/src/channel/server/State.ts
+++ b/sdk/src/channel/server/State.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_FEE,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
+  STELLAR_TESTNET,
   type NetworkId,
 } from '../../constants.js'
 import { DEFAULT_SIM_TIMEOUT_SECS } from '../../shared/defaults.js'
@@ -61,7 +62,7 @@ export type ChannelState = {
 export async function getChannelState(
   parameters: getChannelState.Parameters,
 ): Promise<ChannelState> {
-  const { channel: channelAddress, network = 'testnet', rpcUrl, sourceAccount } = parameters
+  const { channel: channelAddress, network = STELLAR_TESTNET, rpcUrl, sourceAccount } = parameters
 
   const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
   const networkPassphrase = NETWORK_PASSPHRASE[network]
@@ -132,7 +133,7 @@ export declare namespace getChannelState {
   type Parameters = {
     /** Channel contract address (C...). */
     channel: string
-    /** Stellar network. @default 'testnet' */
+    /** Stellar network. @default 'stellar:testnet' */
     network?: NetworkId
     /** Custom Soroban RPC URL. */
     rpcUrl?: string

--- a/sdk/src/channel/server/Watcher.ts
+++ b/sdk/src/channel/server/Watcher.ts
@@ -1,5 +1,5 @@
 import { rpc, xdr } from '@stellar/stellar-sdk'
-import { SOROBAN_RPC_URLS, type NetworkId } from '../../constants.js'
+import { SOROBAN_RPC_URLS, STELLAR_TESTNET, type NetworkId } from '../../constants.js'
 import { scValToBigInt } from '../../shared/scval.js'
 
 // ---------------------------------------------------------------------------
@@ -43,7 +43,7 @@ const KNOWN_TOPICS = new Set(['close', 'close_start', 'refund', 'top_up'])
 export function watchChannel(parameters: watchChannel.Parameters): () => void {
   const {
     channel,
-    network = 'testnet',
+    network = STELLAR_TESTNET,
     rpcUrl,
     intervalMs = 5_000,
     onEvent,
@@ -191,7 +191,7 @@ export declare namespace watchChannel {
   interface Parameters {
     /** Channel contract address (C...). */
     channel: string
-    /** Network identifier. Defaults to 'testnet'. */
+    /** Network identifier. Defaults to 'stellar:testnet'. */
     network?: NetworkId
     /** Custom Soroban RPC URL. */
     rpcUrl?: string

--- a/sdk/src/charge/Methods.ts
+++ b/sdk/src/charge/Methods.ts
@@ -42,7 +42,21 @@ export const charge = Method.from({
         z.object({
           /** CAIP-2 network identifier (e.g. "stellar:testnet", "stellar:pubnet"). */
           network: z.string(),
-          /** Whether the server will sponsor transaction fees. */
+          /**
+           * Whether the server sponsors the transaction.
+           *
+           * When `true`, the server provides the source account, sequence
+           * number, and envelope signature. The client **must** use pull mode
+           * (push is rejected) and build with an all-zeros placeholder source,
+           * signing only the Soroban authorization entries.
+           *
+           * This flag is set automatically by the server when a `feePayer`
+           * configuration is provided. The optional `feeBumpSigner` within
+           * `feePayer` wraps the sponsored transaction in a
+           * `FeeBumpTransaction` — it only applies to the sponsored path
+           * since unsponsored transactions must be submitted as-is per the
+           * spec.
+           */
           feePayer: z.optional(z.boolean()),
         }),
       ),

--- a/sdk/src/charge/client/Charge.test.ts
+++ b/sdk/src/charge/client/Charge.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@stellar/stellar-sdk'
 import { Challenge } from 'mppx'
 import { describe, expect, it, vi } from 'vitest'
-import { CAIP2_TO_NETWORK, USDC_SAC_TESTNET } from '../../constants.js'
+import { USDC_SAC_TESTNET } from '../../constants.js'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 const mockGetAccount = vi.fn()
@@ -241,37 +241,21 @@ describe('charge createCredential', () => {
   })
 })
 
-// ── CAIP-2 and DID-PKH ────────────────────────────────────────────────────
-
-describe('CAIP-2 network mapping', () => {
-  it('maps stellar:testnet to testnet', () => {
-    expect(CAIP2_TO_NETWORK['stellar:testnet']).toBe('testnet')
-  })
-
-  it('maps stellar:pubnet to public', () => {
-    expect(CAIP2_TO_NETWORK['stellar:pubnet']).toBe('public')
-  })
-
-  it('returns undefined for unknown CAIP-2 identifiers', () => {
-    expect(CAIP2_TO_NETWORK['stellar:unknown']).toBeUndefined()
-  })
-})
+// ── DID-PKH ─────────────────────────────────────────────────────────────
 
 describe('DID-PKH format', () => {
-  it('constructs correct DID-PKH from CAIP-2 network and public key', () => {
+  it('constructs correct DID-PKH from network and public key', () => {
     const kp = Keypair.random()
-    const caip2Network = 'stellar:testnet'
-    const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
-    const source = `did:pkh:stellar:${caip2Component}:${kp.publicKey()}`
+    const network = 'stellar:testnet'
+    const source = `did:pkh:${network}:${kp.publicKey()}`
 
     expect(source).toMatch(/^did:pkh:stellar:testnet:G[A-Z0-9]{55}$/)
   })
 
   it('uses pubnet component for mainnet', () => {
     const kp = Keypair.random()
-    const caip2Network = 'stellar:pubnet'
-    const caip2Component = caip2Network.split(':')[1] ?? 'testnet'
-    const source = `did:pkh:stellar:${caip2Component}:${kp.publicKey()}`
+    const network = 'stellar:pubnet'
+    const source = `did:pkh:${network}:${kp.publicKey()}`
 
     expect(source).toMatch(/^did:pkh:stellar:pubnet:G[A-Z0-9]{55}$/)
   })

--- a/sdk/src/charge/client/Charge.test.ts
+++ b/sdk/src/charge/client/Charge.test.ts
@@ -260,3 +260,27 @@ describe('DID-PKH format', () => {
     expect(source).toMatch(/^did:pkh:stellar:pubnet:G[A-Z0-9]{55}$/)
   })
 })
+
+describe('network validation', () => {
+  it('throws on unsupported network identifier', async () => {
+    const method = charge({ keypair: TEST_KEYPAIR })
+    const challenge = mockChallenge({
+      methodDetails: { network: 'stellar:futurenet' },
+    })
+
+    await expect(
+      method.createCredential({ challenge: challenge as any, context: {} as any }),
+    ).rejects.toThrow('Unsupported Stellar network identifier: "stellar:futurenet"')
+  })
+
+  it('throws on old-style network shorthand', async () => {
+    const method = charge({ keypair: TEST_KEYPAIR })
+    const challenge = mockChallenge({
+      methodDetails: { network: 'testnet' },
+    })
+
+    await expect(
+      method.createCredential({ challenge: challenge as any, context: {} as any }),
+    ).rejects.toThrow('Unsupported Stellar network identifier: "testnet"')
+  })
+})

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -14,12 +14,12 @@ import { Credential, Method } from 'mppx'
 import { z } from 'zod/mini'
 import {
   ALL_ZEROS,
-  CAIP2_TO_NETWORK,
   DEFAULT_DECIMALS,
   DEFAULT_LEDGER_CLOSE_TIME,
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
+  STELLAR_TESTNET,
   type NetworkId,
 } from '../../constants.js'
 import * as Methods from '../Methods.js'
@@ -87,8 +87,7 @@ export function charge(parameters: charge.Parameters) {
       const { request } = challenge
       const { amount, currency, recipient } = request
 
-      const caip2Network = request.methodDetails?.network ?? 'stellar:testnet'
-      const network: NetworkId = CAIP2_TO_NETWORK[caip2Network] ?? 'testnet'
+      const network: NetworkId = (request.methodDetails?.network as NetworkId) ?? STELLAR_TESTNET
 
       onProgress?.({
         type: 'challenge',
@@ -188,8 +187,7 @@ export function charge(parameters: charge.Parameters) {
         const signedXdr = prepared.toEnvelope().toXDR('base64')
         onProgress?.({ type: 'signed', transaction: signedXdr })
 
-        const didComponent = network === 'public' ? 'pubnet' : network
-        const source = `did:pkh:stellar:${didComponent}:${keypair.publicKey()}`
+        const source = `did:pkh:${network}:${keypair.publicKey()}`
 
         return Credential.serialize({
           challenge,
@@ -232,8 +230,7 @@ export function charge(parameters: charge.Parameters) {
       const signedXdr = prepared.toXDR()
       onProgress?.({ type: 'signed', transaction: signedXdr })
 
-      const didComponent = network === 'public' ? 'pubnet' : network
-      const source = `did:pkh:stellar:${didComponent}:${keypair.publicKey()}`
+      const source = `did:pkh:${network}:${keypair.publicKey()}`
 
       if (effectiveMode === 'push') {
         // Client broadcasts

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -19,13 +19,12 @@ import {
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
-  STELLAR_TESTNET,
-  type NetworkId,
 } from '../../constants.js'
 import * as Methods from '../Methods.js'
 import { fromBaseUnits } from '../Methods.js'
 import { StellarMppError } from '../../shared/errors.js'
 import { resolveKeypair } from '../../shared/keypairs.js'
+import { resolveNetworkId } from '../../shared/validation.js'
 import { pollTransaction } from '../../shared/poll.js'
 import {
   DEFAULT_POLL_MAX_ATTEMPTS,
@@ -87,7 +86,7 @@ export function charge(parameters: charge.Parameters) {
       const { request } = challenge
       const { amount, currency, recipient } = request
 
-      const network: NetworkId = (request.methodDetails?.network as NetworkId) ?? STELLAR_TESTNET
+      const network = resolveNetworkId(request.methodDetails?.network)
 
       onProgress?.({
         type: 'challenge',

--- a/sdk/src/charge/server/Charge.test.ts
+++ b/sdk/src/charge/server/Charge.test.ts
@@ -68,7 +68,7 @@ describe('stellar server charge', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      network: 'public',
+      network: 'stellar:pubnet',
     })
     expect(method.name).toBe('stellar')
   })
@@ -137,7 +137,7 @@ describe('charge request transform', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      network: 'testnet',
+      network: 'stellar:testnet',
     })
     const transformed = (method as any).request({
       request: { amount: '1', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },
@@ -149,7 +149,7 @@ describe('charge request transform', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      network: 'public',
+      network: 'stellar:pubnet',
     })
     const transformed = (method as any).request({
       request: { amount: '1', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },

--- a/sdk/src/charge/server/Charge.test.ts
+++ b/sdk/src/charge/server/Charge.test.ts
@@ -82,38 +82,38 @@ describe('stellar server charge', () => {
     expect(method.name).toBe('stellar')
   })
 
-  it('accepts signer as Keypair', () => {
+  it('accepts feePayer with envelopeSigner as Keypair', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      signer: Keypair.random(),
+      feePayer: { envelopeSigner: Keypair.random() },
     })
     expect(method.name).toBe('stellar')
   })
 
-  it('accepts signer as secret key string', () => {
+  it('accepts feePayer with envelopeSigner as secret key string', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      signer: Keypair.random().secret(),
+      feePayer: { envelopeSigner: Keypair.random().secret() },
     })
     expect(method.name).toBe('stellar')
   })
 
-  it('accepts feeBumpSigner as Keypair', () => {
+  it('accepts feePayer with feeBumpSigner as Keypair', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      feeBumpSigner: Keypair.random(),
+      feePayer: { envelopeSigner: Keypair.random(), feeBumpSigner: Keypair.random() },
     })
     expect(method.name).toBe('stellar')
   })
 
-  it('accepts feeBumpSigner as secret key string', () => {
+  it('accepts feePayer with feeBumpSigner as secret key string', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      feeBumpSigner: Keypair.random().secret(),
+      feePayer: { envelopeSigner: Keypair.random(), feeBumpSigner: Keypair.random().secret() },
     })
     expect(method.name).toBe('stellar')
   })
@@ -157,11 +157,11 @@ describe('charge request transform', () => {
     expect(transformed.methodDetails.network).toBe('stellar:pubnet')
   })
 
-  it('includes feePayer when signer is configured', () => {
+  it('includes feePayer when feePayer is configured', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      signer: Keypair.random(),
+      feePayer: { envelopeSigner: Keypair.random() },
     })
     const transformed = (method as any).request({
       request: { amount: '1', currency: USDC_SAC_TESTNET, recipient: RECIPIENT },
@@ -169,7 +169,7 @@ describe('charge request transform', () => {
     expect(transformed.methodDetails.feePayer).toBe(true)
   })
 
-  it('omits feePayer when no signer configured', () => {
+  it('omits feePayer when no feePayer configured', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
@@ -243,7 +243,7 @@ describe('charge hash+feePayer rejection', () => {
     const method = charge({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
-      signer: Keypair.random(),
+      feePayer: { envelopeSigner: Keypair.random() },
     })
 
     await expect(
@@ -423,7 +423,7 @@ describe('charge transaction verification', () => {
     ).rejects.toThrow('matching SAC transfer invocation')
   })
 
-  it('rejects sponsored source without signer configured', async () => {
+  it('rejects sponsored source without feePayer configured', async () => {
     const tx = buildTransferTx({
       source: ALL_ZEROS,
       from: PAYER.publicKey(),
@@ -433,12 +433,12 @@ describe('charge transaction verification', () => {
     })
 
     const cred = makeTransactionCredential(tx.toXDR())
-    // No signer configured
+    // No feePayer configured
     const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
 
     await expect(
       method.verify({ credential: cred as any, request: cred.challenge.request }),
-    ).rejects.toThrow('sponsored source account but the server is not configured with a signer')
+    ).rejects.toThrow('sponsored source account but the server has no feePayer configuration')
   })
 
   it('rejects unsupported credential type', async () => {

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -10,12 +10,12 @@ import {
 import { Method, Receipt, Store } from 'mppx'
 import {
   ALL_ZEROS,
-  CAIP2_NETWORK,
   DEFAULT_DECIMALS,
   DEFAULT_LEDGER_CLOSE_TIME,
   DEFAULT_TIMEOUT,
   NETWORK_PASSPHRASE,
   SOROBAN_RPC_URLS,
+  STELLAR_TESTNET,
   type NetworkId,
 } from '../../constants.js'
 import * as Methods from '../Methods.js'
@@ -45,7 +45,7 @@ export function charge(parameters: charge.Parameters) {
     feeBumpSigner: feeBumpSignerParam,
     logger = noopLogger,
     maxFeeBumpStroops = DEFAULT_MAX_FEE_BUMP_STROOPS,
-    network = 'testnet',
+    network = STELLAR_TESTNET,
     pollDelayMs = DEFAULT_POLL_DELAY_MS,
     pollMaxAttempts = DEFAULT_POLL_MAX_ATTEMPTS,
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
@@ -78,7 +78,7 @@ export function charge(parameters: charge.Parameters) {
         ...request,
         amount: toBaseUnits(request.amount, decimals),
         methodDetails: {
-          network: CAIP2_NETWORK[network],
+          network,
           ...(signerKeypair ? { feePayer: true } : {}),
         },
       }

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -42,7 +42,7 @@ export function charge(parameters: charge.Parameters) {
   const {
     currency,
     decimals = DEFAULT_DECIMALS,
-    feeBumpSigner: feeBumpSignerParam,
+    feePayer,
     logger = noopLogger,
     maxFeeBumpStroops = DEFAULT_MAX_FEE_BUMP_STROOPS,
     network = STELLAR_TESTNET,
@@ -52,7 +52,6 @@ export function charge(parameters: charge.Parameters) {
     recipient,
     rpcUrl,
     simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
-    signer: signerParam,
     store,
   } = parameters
 
@@ -60,9 +59,10 @@ export function charge(parameters: charge.Parameters) {
   const networkPassphrase = NETWORK_PASSPHRASE[network]
   const server = new rpc.Server(resolvedRpcUrl)
 
-  const signerKeypair = signerParam ? resolveKeypair(signerParam) : undefined
-
-  const feeBumpKeypair = feeBumpSignerParam ? resolveKeypair(feeBumpSignerParam) : undefined
+  const signerKeypair = feePayer ? resolveKeypair(feePayer.envelopeSigner) : undefined
+  const feeBumpKeypair = feePayer?.feeBumpSigner
+    ? resolveKeypair(feePayer.feeBumpSigner)
+    : undefined
 
   // Serialize verify operations to prevent concurrent race conditions
   // on tx hash deduplication (get/put is not atomic).
@@ -199,10 +199,10 @@ export function charge(parameters: charge.Parameters) {
 
         if (!signerKeypair && tx.source === ALL_ZEROS) {
           logger.warn(`${LOG_PREFIX} Verification failed`, {
-            error: 'Sponsored source without signer',
+            error: 'Sponsored source without feePayer',
           })
           throw new PaymentVerificationError(
-            `${LOG_PREFIX} Transaction uses a sponsored source account but the server is not configured with a signer.`,
+            `${LOG_PREFIX} Transaction uses a sponsored source account but the server has no feePayer configuration.`,
             {},
           )
         }
@@ -246,6 +246,16 @@ export function charge(parameters: charge.Parameters) {
 
           rebuiltTx.sign(signerKeypair)
           txToSubmit = rebuiltTx
+
+          // Fee bump wrapping (sponsored path only — spec requires
+          // unsponsored transactions to be submitted without modification)
+          if (feeBumpKeypair) {
+            logger.debug(`${LOG_PREFIX} Fee bump wrapping`)
+            txToSubmit = wrapFeeBump(txToSubmit, feeBumpKeypair, {
+              networkPassphrase,
+              maxFeeStroops: maxFeeBumpStroops,
+            })
+          }
         } else {
           // ── Unsponsored path ────────────────────────────────────────
 
@@ -269,15 +279,6 @@ export function charge(parameters: charge.Parameters) {
             expectedRecipient,
             signerKeypair?.publicKey(),
           )
-        }
-
-        // ── Fee bump wrapping ───────────────────────────────────────
-        if (feeBumpKeypair) {
-          logger.debug(`${LOG_PREFIX} Fee bump wrapping`)
-          txToSubmit = wrapFeeBump(txToSubmit, feeBumpKeypair, {
-            networkPassphrase,
-            maxFeeStroops: maxFeeBumpStroops,
-          })
         }
 
         // ── Settlement ──────────────────────────────────────────────
@@ -672,8 +673,20 @@ export declare namespace charge {
     decimals?: number
     network?: NetworkId
     rpcUrl?: string
-    signer?: Keypair | string
-    feeBumpSigner?: Keypair | string
+    /**
+     * Server-sponsored fee configuration.
+     *
+     * When set, the challenge includes `methodDetails.feePayer: true` which
+     * tells the client to use pull mode with an all-zeros placeholder source.
+     * The server rebuilds the transaction with its own account and signs the
+     * envelope.
+     */
+    feePayer?: {
+      /** Keypair providing the source account and envelope signature. */
+      envelopeSigner: Keypair | string
+      /** Optional fee bump signer — wraps the sponsored tx in a FeeBumpTransaction. */
+      feeBumpSigner?: Keypair | string
+    }
     store?: Store.Store
     maxFeeBumpStroops?: number
     pollMaxAttempts?: number

--- a/sdk/src/constants.test.ts
+++ b/sdk/src/constants.test.ts
@@ -1,22 +1,26 @@
 import { describe, expect, it } from 'vitest'
 import * as constants from './constants.js'
 
+const { STELLAR_PUBNET, STELLAR_TESTNET } = constants
+
 describe('constants', () => {
-  it('exports NETWORK_PASSPHRASE for public and testnet', () => {
-    expect(constants.NETWORK_PASSPHRASE.public).toBe(
+  it('exports NETWORK_PASSPHRASE for pubnet and testnet', () => {
+    expect(constants.NETWORK_PASSPHRASE[STELLAR_PUBNET]).toBe(
       'Public Global Stellar Network ; September 2015',
     )
-    expect(constants.NETWORK_PASSPHRASE.testnet).toBe('Test SDF Network ; September 2015')
+    expect(constants.NETWORK_PASSPHRASE[STELLAR_TESTNET]).toBe('Test SDF Network ; September 2015')
   })
 
   it('exports SOROBAN_RPC_URLS', () => {
-    expect(constants.SOROBAN_RPC_URLS.public).toBe('https://soroban-rpc.mainnet.stellar.gateway.fm')
-    expect(constants.SOROBAN_RPC_URLS.testnet).toBe('https://soroban-testnet.stellar.org')
+    expect(constants.SOROBAN_RPC_URLS[STELLAR_PUBNET]).toBe(
+      'https://soroban-rpc.mainnet.stellar.gateway.fm',
+    )
+    expect(constants.SOROBAN_RPC_URLS[STELLAR_TESTNET]).toBe('https://soroban-testnet.stellar.org')
   })
 
   it('exports HORIZON_URLS', () => {
-    expect(constants.HORIZON_URLS.public).toBe('https://horizon.stellar.org')
-    expect(constants.HORIZON_URLS.testnet).toBe('https://horizon-testnet.stellar.org')
+    expect(constants.HORIZON_URLS[STELLAR_PUBNET]).toBe('https://horizon.stellar.org')
+    expect(constants.HORIZON_URLS[STELLAR_TESTNET]).toBe('https://horizon-testnet.stellar.org')
   })
 
   it('exports USDC SAC contract addresses', () => {
@@ -38,10 +42,10 @@ describe('constants', () => {
   })
 
   it('exports SAC_ADDRESSES map', () => {
-    expect(constants.SAC_ADDRESSES.public.USDC).toBe(constants.USDC_SAC_MAINNET)
-    expect(constants.SAC_ADDRESSES.testnet.USDC).toBe(constants.USDC_SAC_TESTNET)
-    expect(constants.SAC_ADDRESSES.public.XLM).toBe(constants.XLM_SAC_MAINNET)
-    expect(constants.SAC_ADDRESSES.testnet.XLM).toBe(constants.XLM_SAC_TESTNET)
+    expect(constants.SAC_ADDRESSES[STELLAR_PUBNET].USDC).toBe(constants.USDC_SAC_MAINNET)
+    expect(constants.SAC_ADDRESSES[STELLAR_TESTNET].USDC).toBe(constants.USDC_SAC_TESTNET)
+    expect(constants.SAC_ADDRESSES[STELLAR_PUBNET].XLM).toBe(constants.XLM_SAC_MAINNET)
+    expect(constants.SAC_ADDRESSES[STELLAR_TESTNET].XLM).toBe(constants.XLM_SAC_TESTNET)
   })
 
   it('exports DEFAULT_DECIMALS as 7', () => {

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -1,12 +1,18 @@
 import { Networks } from '@stellar/stellar-sdk'
 
 // ---------------------------------------------------------------------------
-// Networks
+// Networks (CAIP-2 identifiers)
 // ---------------------------------------------------------------------------
 
+/** Stellar testnet CAIP-2 chain identifier. */
+export const STELLAR_TESTNET = 'stellar:testnet' as const
+
+/** Stellar mainnet (pubnet) CAIP-2 chain identifier. */
+export const STELLAR_PUBNET = 'stellar:pubnet' as const
+
 export const NETWORK_PASSPHRASE = {
-  public: Networks.PUBLIC,
-  testnet: Networks.TESTNET,
+  [STELLAR_PUBNET]: Networks.PUBLIC,
+  [STELLAR_TESTNET]: Networks.TESTNET,
 } as const
 
 export type NetworkId = keyof typeof NETWORK_PASSPHRASE
@@ -16,13 +22,13 @@ export type NetworkId = keyof typeof NETWORK_PASSPHRASE
 // ---------------------------------------------------------------------------
 
 export const SOROBAN_RPC_URLS: Record<NetworkId, string> = {
-  public: 'https://soroban-rpc.mainnet.stellar.gateway.fm',
-  testnet: 'https://soroban-testnet.stellar.org',
+  [STELLAR_PUBNET]: 'https://soroban-rpc.mainnet.stellar.gateway.fm',
+  [STELLAR_TESTNET]: 'https://soroban-testnet.stellar.org',
 }
 
 export const HORIZON_URLS: Record<NetworkId, string> = {
-  public: 'https://horizon.stellar.org',
-  testnet: 'https://horizon-testnet.stellar.org',
+  [STELLAR_PUBNET]: 'https://horizon.stellar.org',
+  [STELLAR_TESTNET]: 'https://horizon-testnet.stellar.org',
 }
 
 // ---------------------------------------------------------------------------
@@ -43,36 +49,15 @@ export const XLM_SAC_TESTNET = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU
 
 /** Map from network to well-known SAC addresses. */
 export const SAC_ADDRESSES = {
-  public: {
+  [STELLAR_PUBNET]: {
     USDC: USDC_SAC_MAINNET,
     XLM: XLM_SAC_MAINNET,
   },
-  testnet: {
+  [STELLAR_TESTNET]: {
     USDC: USDC_SAC_TESTNET,
     XLM: XLM_SAC_TESTNET,
   },
 } as const
-
-// ---------------------------------------------------------------------------
-// CAIP-2 network identifiers
-// ---------------------------------------------------------------------------
-
-/**
- * Maps internal network IDs to CAIP-2 chain identifiers.
- * @see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md
- */
-export const CAIP2_NETWORK: Record<NetworkId, string> = {
-  public: 'stellar:pubnet',
-  testnet: 'stellar:testnet',
-}
-
-/**
- * Reverse map: CAIP-2 chain identifier → internal NetworkId.
- */
-export const CAIP2_TO_NETWORK: Record<string, NetworkId | undefined> = {
-  'stellar:pubnet': 'public',
-  'stellar:testnet': 'testnet',
-}
 
 // ---------------------------------------------------------------------------
 // Defaults

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,8 +4,6 @@ export * as ChannelMethods from './channel/Methods.js'
 
 // Constants (public)
 export {
-  CAIP2_NETWORK,
-  CAIP2_TO_NETWORK,
   DEFAULT_CHALLENGE_EXPIRY,
   DEFAULT_DECIMALS,
   DEFAULT_FEE,
@@ -15,6 +13,8 @@ export {
   NETWORK_PASSPHRASE,
   SAC_ADDRESSES,
   SOROBAN_RPC_URLS,
+  STELLAR_PUBNET,
+  STELLAR_TESTNET,
   USDC_SAC_MAINNET,
   USDC_SAC_TESTNET,
   XLM_SAC_MAINNET,

--- a/sdk/src/shared/fee-bump.ts
+++ b/sdk/src/shared/fee-bump.ts
@@ -6,6 +6,15 @@ export interface FeeBumpOptions {
   maxFeeStroops?: number
 }
 
+/**
+ * Wraps a transaction in a `FeeBumpTransaction`.
+ *
+ * The inner transaction's source account and signatures remain intact — the
+ * outer fee bump only overrides who pays the network fee at the protocol
+ * level.
+ *
+ * Already-wrapped `FeeBumpTransaction` instances are returned unchanged.
+ */
 export function wrapFeeBump(
   tx: Transaction | FeeBumpTransaction,
   signer: Keypair,

--- a/sdk/src/shared/validation.test.ts
+++ b/sdk/src/shared/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validateHexSignature, validateAmount } from './validation.js'
+import { validateHexSignature, validateAmount, resolveNetworkId } from './validation.js'
 
 describe('validateHexSignature', () => {
   it('accepts valid 128-char hex signature', () => {
@@ -21,6 +21,39 @@ describe('validateHexSignature', () => {
 
   it('accepts custom expected length', () => {
     expect(() => validateHexSignature('abcd1234', 8)).not.toThrow()
+  })
+})
+
+describe('resolveNetworkId', () => {
+  it('returns stellar:testnet when network is null', () => {
+    expect(resolveNetworkId(null)).toBe('stellar:testnet')
+  })
+
+  it('returns stellar:testnet when network is undefined', () => {
+    expect(resolveNetworkId(undefined)).toBe('stellar:testnet')
+  })
+
+  it('accepts stellar:testnet', () => {
+    expect(resolveNetworkId('stellar:testnet')).toBe('stellar:testnet')
+  })
+
+  it('accepts stellar:pubnet', () => {
+    expect(resolveNetworkId('stellar:pubnet')).toBe('stellar:pubnet')
+  })
+
+  it('throws on unsupported network with list of supported networks', () => {
+    expect(() => resolveNetworkId('stellar:futurenet')).toThrow(
+      'Unsupported Stellar network identifier: "stellar:futurenet". Supported networks: stellar:pubnet, stellar:testnet',
+    )
+  })
+
+  it('throws on old-style network identifiers', () => {
+    expect(() => resolveNetworkId('testnet')).toThrow('Unsupported Stellar network identifier')
+    expect(() => resolveNetworkId('public')).toThrow('Unsupported Stellar network identifier')
+  })
+
+  it('throws on non-string values', () => {
+    expect(() => resolveNetworkId(42)).toThrow('Unsupported Stellar network identifier')
   })
 })
 

--- a/sdk/src/shared/validation.ts
+++ b/sdk/src/shared/validation.ts
@@ -1,3 +1,4 @@
+import { NETWORK_PASSPHRASE, STELLAR_TESTNET, type NetworkId } from '../constants.js'
 import { StellarMppError } from './errors.js'
 
 export function validateHexSignature(hex: string, expectedLength: number = 128): void {
@@ -6,6 +7,15 @@ export function validateHexSignature(hex: string, expectedLength: number = 128):
       `Invalid signature: expected ${expectedLength} hex characters, got ${hex.length}`,
     )
   }
+}
+
+export function resolveNetworkId(network: unknown): NetworkId {
+  if (network == null) return STELLAR_TESTNET
+  if (typeof network === 'string' && network in NETWORK_PASSPHRASE) return network as NetworkId
+  const supported = Object.keys(NETWORK_PASSPHRASE).join(', ')
+  throw new StellarMppError(
+    `Unsupported Stellar network identifier: "${network}". Supported networks: ${supported}`,
+  )
 }
 
 export function validateAmount(amount: string): void {


### PR DESCRIPTION
## What
- Migrate `NetworkId` from internal shorthand (`'testnet' | 'public'`) to CAIP-2 identifiers (`'stellar:testnet' | 'stellar:pubnet'`) used directly as map keys, eliminating the `CAIP2_NETWORK` / `CAIP2_TO_NETWORK` conversion layers
- Restructure charge server's `signer` + `feeBumpSigner` into a nested `feePayer: { envelopeSigner, feeBumpSigner? }` — makes `feeBumpSigner` structurally impossible without the envelope signer at the type level
- Move fee bump wrapping inside the sponsored path only — per spec, unsponsored transactions must be submitted as-is ("Server MUST NOT modify")
- Simplify DID-PKH construction since network is now the CAIP-2 identifier directly

## Why
- The Stellar Charge spec (draft-stellar-charge-00) requires CAIP-2 network identifiers on the wire. Using them as `NetworkId` internally removes unnecessary conversion complexity.
- The spec says unsponsored pull-mode transactions must be submitted without modification. Fee bumping an unsponsored tx violates this, and the flat `signer` / `feeBumpSigner` API allowed that invalid configuration. Nesting `feeBumpSigner` inside `feePayer` prevents it at the type level.
- Naming aligned with Tempo's MPP ecosystem (`tempo.charge({ feePayer: ... })`).

## Example

### Before (charge server)
```ts
stellar.charge({
  recipient: 'G...',
  currency: USDC_SAC_TESTNET,
  signer: Keypair.fromSecret('S...'),
  feeBumpSigner: Keypair.fromSecret('S...'),
})
```

### After (charge server)
```ts
// Sponsored with fee bumping
stellar.charge({
  recipient: 'G...',
  currency: USDC_SAC_TESTNET,
  feePayer: {
    envelopeSigner: Keypair.fromSecret('S...'),
    feeBumpSigner: Keypair.fromSecret('S...'),
  },
})

// Unsponsored (no feePayer — both push and pull available)
stellar.charge({
  recipient: 'G...',
  currency: USDC_SAC_TESTNET,
})
```