### PR TITLE
refactor: nest channel signer into feePayer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nest channel server `signer` + `feeBumpSigner` into `feePayer: { envelopeSigner, feeBumpSigner? }` to match charge server convention [#34](https://github.com/stellar/stellar-mpp-sdk/pull/34)
+
 ## [0.3.0] - 2026-03-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -275,8 +275,10 @@ stellar.channel({
   rpcUrl?: string,                // custom Soroban RPC URL
   sourceAccount?: string,         // funded G... address for simulations
   store?: Store.Store,            // replay protection + cumulative amount tracking
-  signer?: Keypair | string,      // keypair for signing close/open transactions
-  feeBumpSigner?: Keypair | string, // fee bump signer for close/open transactions
+  feePayer?: {                     // fee payer for close/open transactions
+    envelopeSigner: Keypair | string,   // source account + envelope signer
+    feeBumpSigner?: Keypair | string,   // wraps tx in FeeBumpTransaction
+  },
   checkOnChainState?: boolean,    // detect on-chain disputes (default: false)
   onDisputeDetected?: (state) => void, // callback when close_start detected
   maxFeeBumpStroops?: number,     // max fee bump in stroops (default: 10,000,000)
@@ -433,8 +435,8 @@ await close({
   channel: 'CABC...', // channel contract address
   amount: 8000000n, // commitment amount to close with
   signature: commitmentSigBytes, // ed25519 signature from the latest commitment
-  signer: recipientKeypair, // keypair to sign the close transaction
-  network: 'testnet',
+  feePayer: { envelopeSigner: recipientKeypair },
+  network: 'stellar:testnet',
 })
 ```
 

--- a/examples/channel-close.ts
+++ b/examples/channel-close.ts
@@ -74,7 +74,7 @@ const txHash = await close({
   channel: CHANNEL_CONTRACT,
   amount: AMOUNT,
   signature,
-  signer: closeKey,
+  feePayer: { envelopeSigner: closeKey },
   network: NETWORK,
 })
 

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -278,21 +278,21 @@ describe('stellar server channel', () => {
     expect(method.name).toBe('stellar')
   })
 
-  it('accepts signer for close transaction signing', () => {
+  it('accepts feePayer with envelopeSigner', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
-      signer: Keypair.random(),
+      feePayer: { envelopeSigner: Keypair.random() },
       store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
   })
 
-  it('accepts feeBumpSigner for channel transactions', () => {
+  it('accepts feePayer with envelopeSigner and feeBumpSigner', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
-      feeBumpSigner: Keypair.random(),
+      feePayer: { envelopeSigner: Keypair.random(), feeBumpSigner: Keypair.random() },
       store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
@@ -566,7 +566,7 @@ describe('stellar server channel verification', () => {
         credential: credential as any,
         request: credential.challenge.request,
       }),
-    ).rejects.toThrow('Close action requires a signer')
+    ).rejects.toThrow('Close action requires a feePayer')
   })
 })
 
@@ -972,7 +972,7 @@ describe('close()', () => {
       channel: CHANNEL_ADDRESS,
       amount: 5000000n,
       signature,
-      signer,
+      feePayer: { envelopeSigner: signer },
       network: 'stellar:testnet',
     })
 
@@ -993,7 +993,7 @@ describe('close()', () => {
         channel: CHANNEL_ADDRESS,
         amount: 5000000n,
         signature,
-        signer,
+        feePayer: { envelopeSigner: signer },
         network: 'stellar:testnet',
       }),
     ).rejects.toThrow('sendTransaction returned ERROR')
@@ -1012,7 +1012,7 @@ describe('close()', () => {
         channel: CHANNEL_ADDRESS,
         amount: 5000000n,
         signature,
-        signer,
+        feePayer: { envelopeSigner: signer },
         network: 'stellar:testnet',
       }),
     ).rejects.toThrow('sendTransaction returned DUPLICATE')
@@ -1032,7 +1032,7 @@ describe('close()', () => {
         channel: CHANNEL_ADDRESS,
         amount: 5000000n,
         signature,
-        signer,
+        feePayer: { envelopeSigner: signer },
         network: 'stellar:testnet',
       }),
     ).rejects.toThrow(/failed/i)

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -68,7 +68,7 @@ export function channel(parameters: channel.Parameters) {
     checkOnChainState = false,
     commitmentKey: commitmentKeyParam,
     decimals = DEFAULT_DECIMALS,
-    feeBumpSigner: feeBumpSignerParam,
+    feePayer,
     maxFeeBumpStroops = DEFAULT_MAX_FEE_BUMP_STROOPS,
     network = STELLAR_TESTNET,
     onDisputeDetected,
@@ -77,7 +77,6 @@ export function channel(parameters: channel.Parameters) {
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
     rpcUrl,
     simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
-    signer: signerParam,
     sourceAccount,
     store,
     logger = noopLogger,
@@ -95,8 +94,10 @@ export function channel(parameters: channel.Parameters) {
     return commitmentKeyParam
   })()
 
-  const signerKeypair = signerParam ? resolveKeypair(signerParam) : undefined
-  const feeBumpKeypair = feeBumpSignerParam ? resolveKeypair(feeBumpSignerParam) : undefined
+  const signerKeypair = feePayer ? resolveKeypair(feePayer.envelopeSigner) : undefined
+  const feeBumpKeypair = feePayer?.feeBumpSigner
+    ? resolveKeypair(feePayer.feeBumpSigner)
+    : undefined
 
   // Track cumulative amounts per channel in the store
   const cumulativeKey = `${STORE_PREFIX}:cumulative:${channelAddress}`
@@ -402,7 +403,7 @@ export function channel(parameters: channel.Parameters) {
     if (action === 'close') {
       if (!signerKeypair) {
         throw new ChannelVerificationError(
-          `${LOG_PREFIX} Close action requires a signer to be configured.`,
+          `${LOG_PREFIX} Close action requires a feePayer to be configured.`,
           {},
         )
       }
@@ -701,10 +702,15 @@ export async function close(parameters: {
   amount: bigint
   /** Ed25519 signature for the commitment. */
   signature: Uint8Array
-  /** Keypair to sign the close transaction (source account). */
-  signer: Keypair
-  /** Optional fee bump signer. */
-  feeBumpSigner?: Keypair
+  /**
+   * Fee payer configuration for the close transaction.
+   * `envelopeSigner` provides the source account and signs the envelope.
+   * `feeBumpSigner` optionally wraps the tx in a FeeBumpTransaction.
+   */
+  feePayer: {
+    envelopeSigner: Keypair
+    feeBumpSigner?: Keypair
+  }
   /** Network identifier. */
   network?: NetworkId
   /** Custom RPC URL. */
@@ -724,8 +730,7 @@ export async function close(parameters: {
     channel: channelAddress,
     amount,
     signature,
-    signer,
-    feeBumpSigner,
+    feePayer,
     network = STELLAR_TESTNET,
     rpcUrl,
     maxFeeBumpStroops = DEFAULT_MAX_FEE_BUMP_STROOPS,
@@ -746,6 +751,7 @@ export async function close(parameters: {
     nativeToScVal(Buffer.from(signature), { type: 'bytes' }),
   )
 
+  const signer = feePayer.envelopeSigner
   const account = await server.getAccount(signer.publicKey())
   const tx = new TransactionBuilder(account, {
     fee: DEFAULT_FEE,
@@ -759,8 +765,8 @@ export async function close(parameters: {
   prepared.sign(signer)
 
   let txToSubmit: Transaction | FeeBumpTransaction = prepared
-  if (feeBumpSigner) {
-    txToSubmit = wrapFeeBump(prepared, feeBumpSigner, {
+  if (feePayer.feeBumpSigner) {
+    txToSubmit = wrapFeeBump(prepared, feePayer.feeBumpSigner, {
       networkPassphrase,
       maxFeeStroops: maxFeeBumpStroops,
     })
@@ -811,13 +817,17 @@ export declare namespace channel {
      */
     checkOnChainState?: boolean
     /**
-     * Keypair for signing close transactions (provides sequence number).
+     * Fee payer configuration for on-chain channel operations (close, open).
+     *
+     * `envelopeSigner` provides the source account and signs the envelope.
+     * `feeBumpSigner` optionally wraps the transaction in a FeeBumpTransaction.
+     *
      * Required when handling close credential actions.
-     * Accepts a Stellar secret key string (S...) or a Keypair instance.
      */
-    signer?: Keypair | string
-    /** Optional fee bump signer for close/open transactions. */
-    feeBumpSigner?: Keypair | string
+    feePayer?: {
+      envelopeSigner: Keypair | string
+      feeBumpSigner?: Keypair | string
+    }
     /**
      * Ed25519 public key for verifying commitment signatures.
      * Accepts a Stellar public key string (G...) or a Keypair instance.


### PR DESCRIPTION
## What
- Restructure channel server's flat `signer` + `feeBumpSigner` into nested `feePayer: { envelopeSigner, feeBumpSigner? }` — consistent with the charge server's `feePayer` structure
- Update standalone `close()` function to use the same `feePayer` parameter shape
- Update `channel-close.ts` example and README channel docs

## Why
- Aligns charge and channel APIs under a consistent `feePayer` config pattern, matching the convention used by Tempo (`tempo.session({ feePayer })`) and Solana (`solana({ sponsor: { feePayer } })`)
- Makes `feeBumpSigner` structurally impossible without `envelopeSigner` at the type level

## Example

### Before
```ts
stellar.channel({
  channel: 'CABC...',
  commitmentKey: 'G...',
  signer: Keypair.fromSecret('S...'),
  feeBumpSigner: Keypair.fromSecret('S...'),
})

await close({
  channel: 'CABC...',
  amount: 8000000n,
  signature: sigBytes,
  signer: recipientKeypair,
})
```

### After
```ts
stellar.channel({
  channel: 'CABC...',
  commitmentKey: 'G...',
  feePayer: {
    envelopeSigner: Keypair.fromSecret('S...'),
    feeBumpSigner: Keypair.fromSecret('S...'),
  },
})

await close({
  channel: 'CABC...',
  amount: 8000000n,
  signature: sigBytes,
  feePayer: { envelopeSigner: recipientKeypair },
})
```