### PR TITLE
docs: fix CHANGELOG entries for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Fix CHANGELOG entries for v0.3.0 ([#36](https://github.com/stellar/stellar-mpp-sdk/pull/36))
+### Fixed
 
+- Fix CHANGELOG entries for v0.3.0 ([#36](https://github.com/stellar/stellar-mpp-sdk/pull/36))
 ## [0.3.0] - 2026-03-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix CHANGELOG entries for v0.3.0 ([#36](https://github.com/stellar/stellar-mpp-sdk/pull/36))
+
 ## [0.3.0] - 2026-03-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Fix CHANGELOG entries for v0.3.0 ([#36](https://github.com/stellar/stellar-mpp-sdk/pull/36))
+
 ## [0.3.0] - 2026-03-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nest channel server `signer` + `feeBumpSigner` into `feePayer: { envelopeSigner, feeBumpSigner? }` to match charge server convention [#34](https://github.com/stellar/stellar-mpp-sdk/pull/34)
-
 ## [0.3.0] - 2026-03-31
+
+### Added
+
+- Add [draft-stellar-charge-00](https://paymentauth.org/draft-stellar-charge-00) spec references to README, JSDoc, and charge-flow diagram; fix diagram for spec compliance [#35](https://github.com/stellar/stellar-mpp-sdk/pull/35)
 
 ### Changed
 
 - Align fee-bump transaction handling with the spec and restructure server signer configuration (`feePayer`) to match cross-chain conventions [#33](https://github.com/stellar/stellar-mpp-sdk/pull/33)
+- Nest channel server `signer` + `feeBumpSigner` into `feePayer: { envelopeSigner, feeBumpSigner? }` to match charge server convention [#34](https://github.com/stellar/stellar-mpp-sdk/pull/34)
 
 ## [0.2.1] - 2026-03-30
 

--- a/NOTES_PR.md
+++ b/NOTES_PR.md
@@ -1,0 +1,16 @@
+# Draft Pull Request
+
+**Base branch:** main
+
+## Title
+
+docs: fix CHANGELOG entries for v0.3.0
+
+## What
+
+- Move PR #34 (`feePayer` channel signer refactor) from `[Unreleased]` into the `0.3.0 / Changed` section where it belongs
+- Add missing PR #35 (draft-stellar-charge-00 spec references) under a new `0.3.0 / Added` section
+
+## Why
+
+The last two commits landed on `main` after the `0.3.0` changelog section was drafted, leaving #34 stranded under `[Unreleased]` and #35 absent entirely. This PR corrects the record so the changelog accurately reflects the full 0.3.0 release.


### PR DESCRIPTION
## What
- Move PR #34 (`feePayer` channel signer refactor) from `[Unreleased]` into the `0.3.0 / Changed` section where it belongs
- Add missing PR #35 (draft-stellar-charge-00 spec references) under a new `0.3.0 / Added` section

## Why
The last two commits landed on `main` after the `0.3.0` changelog section was drafted, leaving #34 stranded under `[Unreleased]` and #35 absent entirely. This PR corrects the record so the changelog accurately reflects the full 0.3.0 release.