### PR TITLE
fix(charge): make charge client send transaction with signed auth entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix charge client so it sends a transaction with signed auth entries when the server is sponsoring transaction fees ([#37](https://github.com/stellar/stellar-mpp-sdk/pull/36))
 - Fix CHANGELOG entries for v0.3.0 ([#36](https://github.com/stellar/stellar-mpp-sdk/pull/36))
 
 ## [0.3.0] - 2026-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix charge client so it sends a transaction with signed auth entries when the server is sponsoring transaction fees ([#37](https://github.com/stellar/stellar-mpp-sdk/pull/36))
+- Fix charge client so it sends a transaction with signed auth entries when the server is sponsoring transaction fees ([#37](https://github.com/stellar/stellar-mpp-sdk/pull/37))
 - Fix CHANGELOG entries for v0.3.0 ([#36](https://github.com/stellar/stellar-mpp-sdk/pull/36))
 
 ## [0.3.0] - 2026-03-31

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format-check: ## Check formatting (CI-friendly)
 	pnpm run format:check
 
 test: ## Run tests once (vitest --run)
-	pnpm test -- --run
+	pnpm test --run
 
 test-watch: ## Run tests in watch mode
 	pnpm test

--- a/sdk/src/charge/client/Charge.test.ts
+++ b/sdk/src/charge/client/Charge.test.ts
@@ -3,12 +3,17 @@ import {
   Address,
   Contract,
   Keypair,
+  Operation,
   TransactionBuilder,
+  authorizeInvocation,
   nativeToScVal,
+  xdr,
+  scValToNative,
+  Transaction
 } from '@stellar/stellar-sdk'
 import { Challenge } from 'mppx'
 import { describe, expect, it, vi } from 'vitest'
-import { USDC_SAC_TESTNET } from '../../constants.js'
+import { ALL_ZEROS, NETWORK_PASSPHRASE, STELLAR_TESTNET, USDC_SAC_TESTNET } from '../../constants.js'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 const mockGetAccount = vi.fn()
@@ -66,6 +71,38 @@ function buildMockPreparedTx() {
     new Address(RECIPIENT).toScVal(),
     nativeToScVal(100000n, { type: 'i128' }),
   )
+  return new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  })
+    .addOperation(transferOp)
+    .setTimeout(180)
+    .build()
+}
+
+function buildMockPrepareTxAuthEntry() {
+  const account = new Account(ALL_ZEROS, '0')
+  const contract = new Contract(USDC_SAC_TESTNET)
+  const transferOp = contract.call(
+    'transfer',
+    new Address(TEST_KEYPAIR.publicKey()).toScVal(),
+    new Address(RECIPIENT).toScVal(),
+    nativeToScVal(100000n, { type: 'i128' }),
+  )
+  authorizeInvocation(TEST_KEYPAIR, 1000, new xdr.SorobanAuthorizedInvocation({
+    function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(new xdr.InvokeContractArgs({
+      contractAddress: contract.address().toScAddress(),
+      functionName: 'transfer',
+      args: [
+        nativeToScVal(TEST_KEYPAIR.publicKey(), { type: "address" }),
+        nativeToScVal(RECIPIENT, { type: "address" }),
+        nativeToScVal(100000n, { type: 'i128' })
+      ],
+    })),
+    subInvocations: []
+  })).then((auth) => {
+    transferOp.body().invokeHostFunctionOp().auth().push(auth)
+  })
   return new TransactionBuilder(account, {
     fee: '100',
     networkPassphrase: 'Test SDF Network ; September 2015',
@@ -183,6 +220,62 @@ describe('charge createCredential', () => {
     expect(decoded.payload.type).toBe('transaction')
     expect(typeof decoded.payload.transaction).toBe('string')
     expect(decoded.source).toMatch(/^did:pkh:stellar:testnet:G/)
+  })
+
+  it('produces an auth entry credential in pull mode, when sponsored', async () => {
+    const account = new Account(TEST_KEYPAIR.publicKey(), '0')
+    mockGetAccount.mockResolvedValueOnce(account)
+    const mockTx = buildMockPrepareTxAuthEntry()
+    mockPrepareTransaction.mockResolvedValueOnce(await mockTx)
+    mockGetLatestLedger.mockResolvedValueOnce({ sequence: 50 })
+
+    const method = charge({ keypair: TEST_KEYPAIR, mode: 'pull' })
+    const challenge = mockChallenge({ methodDetails: { network: "stellar:testnet", feePayer: true }})
+
+    const credential = await method.createCredential({
+      challenge: challenge as any,
+      context: {} as any,
+    })
+
+    // Decode the credential and transaction
+    const token = credential.replace(/^Payment\s+/, '')
+    const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
+    const tx = TransactionBuilder.fromXDR(decoded.payload.transaction, NETWORK_PASSPHRASE[STELLAR_TESTNET]) as Transaction
+    const op  = tx.operations[0] as Operation.InvokeHostFunction
+
+    // Should still be a valid transaction payload, but an unsigned envelope
+    expect(decoded.payload.type).toBe('transaction')
+    expect(tx.source).toBe(ALL_ZEROS)
+    expect(tx.signatures.length).toBe(0)
+    expect(tx.operations.length).toBe(1)
+    expect(op.type).toBe('invokeHostFunction')
+
+    // The Operation and auth entry should be valid
+    expect(op.source).toBe(undefined)
+    expect(op.auth?.length).toBe(1)
+    const auth = op.auth![0]
+    expect(auth).toBeDefined()
+    expect(auth.rootInvocation().subInvocations().length).toBe(0)
+
+    // The address credential should be valid
+    const cred = auth.credentials()
+    expect(cred.switch().name).toBe("sorobanCredentialsAddress")
+    expect(Address.fromScAddress(cred.address().address()).toString()).toBe(TEST_KEYPAIR.publicKey())
+    expect(cred.address().signature()).toBeDefined()
+    expect(cred.address().nonce()).toBeDefined()
+    expect(cred.address().signatureExpirationLedger()).toBeDefined()
+
+    // The authorized function invocation should be valid
+    const func = auth.rootInvocation().function().contractFn()
+    expect(Address.fromScAddress(func.contractAddress()).toString()).toBe(USDC_SAC_TESTNET)
+    expect(func.functionName().toString()).toBe("transfer")
+
+    // The authorized function args should be valid
+    const args = func.args()
+    expect(args.length).toBe(3)
+    expect(scValToNative(args[0])).toBe(TEST_KEYPAIR.publicKey())
+    expect(scValToNative(args[1])).toBe(RECIPIENT)
+    expect(scValToNative(args[2])).toBe(100000n)
   })
 
   it('broadcasts and produces hash credential in push mode', async () => {

--- a/sdk/src/charge/client/Charge.test.ts
+++ b/sdk/src/charge/client/Charge.test.ts
@@ -9,11 +9,16 @@ import {
   nativeToScVal,
   xdr,
   scValToNative,
-  Transaction
+  Transaction,
 } from '@stellar/stellar-sdk'
 import { Challenge } from 'mppx'
 import { describe, expect, it, vi } from 'vitest'
-import { ALL_ZEROS, NETWORK_PASSPHRASE, STELLAR_TESTNET, USDC_SAC_TESTNET } from '../../constants.js'
+import {
+  ALL_ZEROS,
+  NETWORK_PASSPHRASE,
+  STELLAR_TESTNET,
+  USDC_SAC_TESTNET,
+} from '../../constants.js'
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 const mockGetAccount = vi.fn()
@@ -89,18 +94,24 @@ function buildMockPrepareTxAuthEntry() {
     new Address(RECIPIENT).toScVal(),
     nativeToScVal(100000n, { type: 'i128' }),
   )
-  authorizeInvocation(TEST_KEYPAIR, 1000, new xdr.SorobanAuthorizedInvocation({
-    function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(new xdr.InvokeContractArgs({
-      contractAddress: contract.address().toScAddress(),
-      functionName: 'transfer',
-      args: [
-        nativeToScVal(TEST_KEYPAIR.publicKey(), { type: "address" }),
-        nativeToScVal(RECIPIENT, { type: "address" }),
-        nativeToScVal(100000n, { type: 'i128' })
-      ],
-    })),
-    subInvocations: []
-  })).then((auth) => {
+  authorizeInvocation(
+    TEST_KEYPAIR,
+    1000,
+    new xdr.SorobanAuthorizedInvocation({
+      function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+        new xdr.InvokeContractArgs({
+          contractAddress: contract.address().toScAddress(),
+          functionName: 'transfer',
+          args: [
+            nativeToScVal(TEST_KEYPAIR.publicKey(), { type: 'address' }),
+            nativeToScVal(RECIPIENT, { type: 'address' }),
+            nativeToScVal(100000n, { type: 'i128' }),
+          ],
+        }),
+      ),
+      subInvocations: [],
+    }),
+  ).then((auth) => {
     transferOp.body().invokeHostFunctionOp().auth().push(auth)
   })
   return new TransactionBuilder(account, {
@@ -230,7 +241,9 @@ describe('charge createCredential', () => {
     mockGetLatestLedger.mockResolvedValueOnce({ sequence: 50 })
 
     const method = charge({ keypair: TEST_KEYPAIR, mode: 'pull' })
-    const challenge = mockChallenge({ methodDetails: { network: "stellar:testnet", feePayer: true }})
+    const challenge = mockChallenge({
+      methodDetails: { network: 'stellar:testnet', feePayer: true },
+    })
 
     const credential = await method.createCredential({
       challenge: challenge as any,
@@ -240,8 +253,11 @@ describe('charge createCredential', () => {
     // Decode the credential and transaction
     const token = credential.replace(/^Payment\s+/, '')
     const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
-    const tx = TransactionBuilder.fromXDR(decoded.payload.transaction, NETWORK_PASSPHRASE[STELLAR_TESTNET]) as Transaction
-    const op  = tx.operations[0] as Operation.InvokeHostFunction
+    const tx = TransactionBuilder.fromXDR(
+      decoded.payload.transaction,
+      NETWORK_PASSPHRASE[STELLAR_TESTNET],
+    ) as Transaction
+    const op = tx.operations[0] as Operation.InvokeHostFunction
 
     // Should still be a valid transaction payload, but an unsigned envelope
     expect(decoded.payload.type).toBe('transaction')
@@ -259,8 +275,10 @@ describe('charge createCredential', () => {
 
     // The address credential should be valid
     const cred = auth.credentials()
-    expect(cred.switch().name).toBe("sorobanCredentialsAddress")
-    expect(Address.fromScAddress(cred.address().address()).toString()).toBe(TEST_KEYPAIR.publicKey())
+    expect(cred.switch().name).toBe('sorobanCredentialsAddress')
+    expect(Address.fromScAddress(cred.address().address()).toString()).toBe(
+      TEST_KEYPAIR.publicKey(),
+    )
     expect(cred.address().signature()).toBeDefined()
     expect(cred.address().nonce()).toBeDefined()
     expect(cred.address().signatureExpirationLedger()).toBeDefined()
@@ -268,7 +286,7 @@ describe('charge createCredential', () => {
     // The authorized function invocation should be valid
     const func = auth.rootInvocation().function().contractFn()
     expect(Address.fromScAddress(func.contractAddress()).toString()).toBe(USDC_SAC_TESTNET)
-    expect(func.functionName().toString()).toBe("transfer")
+    expect(func.functionName().toString()).toBe('transfer')
 
     // The authorized function args should be valid
     const args = func.args()

--- a/sdk/src/charge/client/Charge.ts
+++ b/sdk/src/charge/client/Charge.ts
@@ -162,8 +162,9 @@ export function charge(parameters: charge.Parameters) {
 
         // Sign only the Soroban authorization entries — do NOT sign the
         // transaction envelope (the server will do that after rebuilding).
-        const envelope = prepared.toEnvelope().v1()
-        for (const op of envelope.tx().operations()) {
+        const envelope = prepared.toEnvelope()
+        const v1 = envelope.v1()
+        for (const op of v1.tx().operations()) {
           const body = op.body()
           if (body.switch().value !== StellarXdr.OperationType.invokeHostFunction().value) {
             continue
@@ -185,7 +186,7 @@ export function charge(parameters: charge.Parameters) {
           }
         }
 
-        const signedXdr = prepared.toEnvelope().toXDR('base64')
+        const signedXdr = envelope.toXDR('base64')
         onProgress?.({ type: 'signed', transaction: signedXdr })
 
         const source = `did:pkh:${network}:${keypair.publicKey()}`


### PR DESCRIPTION
The `Charge` client module currently prepares the transaction via simulation with the RPC server, and then checks and signs the auth entries on the underlying transaction. It then sends back to the server a **fresh envelope** which is created again from the `prepareTransaction` response. This change pulls out the transaction envelope from the prepared response, signs the auth entries, and then sends back the XDR from the envelope that was previously pulled/signed from `prepared`.

I was a little surprised that the tests don't pick up on this error, though. I _think_ it might be due to how the transactions are mocked in the tests? I'm a little unclear how the mocking works, though, so it may just be a misunderstanding on my part.

I've also made a small change to the `Makefile` so `make test` (and the more all-encompassing `make check`) function actually does run the tests only once (instead of entering watch mode, which it currently does). If that's better suited to an isolated PR, i'm happy to revert the change here and cherry-pick on a new branch.

The included unit test introduces a new `buildMockPrepareTxAuthEntry` for creating a transaction that's suitable for testing (using low-level XDR constructors), and tests all the aspects of the auth entry I could think. If there are other aspects we could/should test, I'd be happy to include those.