### PR TITLE
fix: address Nemesis and Bug Finder audit findings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 pnpm-lock.yaml
+NOTES_PR.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Nest channel server `signer` + `feeBumpSigner` into `feePayer: { envelopeSigner, feeBumpSigner? }` to match charge server convention [#34](https://github.com/stellar/stellar-mpp-sdk/pull/34)
+- Make `store` required in `channel()` server — channel security model (replay protection, cumulative tracking, post-close rejection) depends entirely on the store; add startup info log advising multi-process deployments to use atomic put-if-absent semantics [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
+- Add optional client-side `store` to `channel()` client — persists signed cumulative and uses `max(local, server-reported)` as baseline, preventing a rogue server from resetting the client's cumulative state [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
 
 ## [0.3.0] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nest channel server `signer` + `feeBumpSigner` into `feePayer: { envelopeSigner, feeBumpSigner? }` to match charge server convention [#34](https://github.com/stellar/stellar-mpp-sdk/pull/34)
 - Make `store` required in `channel()` server — channel security model (replay protection, cumulative tracking, post-close rejection) depends entirely on the store; add startup info log advising multi-process deployments to use atomic put-if-absent semantics [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
 - Add optional client-side `store` to `channel()` client — persists signed cumulative and uses `max(local, server-reported)` as baseline, preventing a rogue server from resetting the client's cumulative state [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
+- Verify SAC transfer `from` address against credential source in both push and pull modes — prevents hash-theft attacks where a third party intercepts a client's tx hash and claims the payment benefit before the legitimate client can [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
 
 ## [0.3.0] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-01
+
+### Changed
+
+- **BREAKING:** Make `store` required in `channel()` server — channel security model (replay protection, cumulative tracking, post-close rejection) depends entirely on the store; add startup info log advising multi-process deployments to use atomic put-if-absent semantics [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
+- **BREAKING:** Verify SEP-41 transfer `from` address against credential source in both push and pull modes — `credential.source` (DID) is now mandatory; prevents hash-theft attacks where a third party intercepts a client's tx hash and claims the payment benefit before the legitimate client can [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
 - Nest channel server `signer` + `feeBumpSigner` into `feePayer: { envelopeSigner, feeBumpSigner? }` to match charge server convention [#34](https://github.com/stellar/stellar-mpp-sdk/pull/34)
-- Make `store` required in `channel()` server — channel security model (replay protection, cumulative tracking, post-close rejection) depends entirely on the store; add startup info log advising multi-process deployments to use atomic put-if-absent semantics [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
-- Add optional client-side `store` to `channel()` client — persists signed cumulative and uses `max(local, server-reported)` as baseline, preventing a rogue server from resetting the client's cumulative state [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
-- Verify SAC transfer `from` address against credential source in both push and pull modes — prevents hash-theft attacks where a third party intercepts a client's tx hash and claims the payment benefit before the legitimate client can [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
+
+### Added
+
+- Optional client-side `store` to `channel()` client — persists signed cumulative and uses `max(local, server-reported)` as baseline, preventing a rogue server from resetting the client's cumulative state [#36](https://github.com/stellar/stellar-mpp-sdk/pull/36)
 
 ## [0.3.0] - 2026-03-31
 
@@ -40,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Env parsing primitives for Stellar-aware configuration
 - Shared utilities: fee bump wrapping, transaction polling with backoff, Soroban simulation, unit conversion, keypair resolution
 
-[Unreleased]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/stellar/stellar-mpp-sdk/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/stellar/stellar-mpp-sdk/releases/tag/v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/mpp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Stellar blockchain payment method for the Machine Payments Protocol (MPP)",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/sdk/src/channel/client/Channel.test.ts
+++ b/sdk/src/channel/client/Channel.test.ts
@@ -303,7 +303,9 @@ describe('client-side cumulative tracking (store)', () => {
 
     await method.createCredential({ challenge: challenge as any, context: {} as any })
 
-    const stored = (await store.get(`stellar:channel:client:${CHANNEL_ADDRESS}:cumulative`)) as {
+    const stored = (await store.get(
+      `stellar:channel:client:stellar:testnet:${CHANNEL_ADDRESS}:cumulative`,
+    )) as {
       amount: string
     }
     expect(stored).not.toBeNull()
@@ -316,7 +318,7 @@ describe('client-side cumulative tracking (store)', () => {
 
     const store = Store.memory()
     // Simulate client has already committed 5000000 locally
-    await store.put(`stellar:channel:client:${CHANNEL_ADDRESS}:cumulative`, {
+    await store.put(`stellar:channel:client:stellar:testnet:${CHANNEL_ADDRESS}:cumulative`, {
       amount: '5000000',
     })
 
@@ -368,7 +370,9 @@ describe('client-side cumulative tracking (store)', () => {
     expect(decoded.payload.amount).toBe('3500000')
 
     // And persists the new cumulative for next call
-    const stored = (await store.get(`stellar:channel:client:${CHANNEL_ADDRESS}:cumulative`)) as {
+    const stored = (await store.get(
+      `stellar:channel:client:stellar:testnet:${CHANNEL_ADDRESS}:cumulative`,
+    )) as {
       amount: string
     }
     expect(stored.amount).toBe('3500000')

--- a/sdk/src/channel/client/Channel.test.ts
+++ b/sdk/src/channel/client/Channel.test.ts
@@ -1,5 +1,5 @@
 import { Keypair } from '@stellar/stellar-sdk'
-import { Challenge } from 'mppx'
+import { Challenge, Store } from 'mppx'
 import { describe, expect, it, vi } from 'vitest'
 
 const mockGetAccount = vi.fn()
@@ -289,6 +289,114 @@ describe('channel createCredential open action', () => {
     const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
     // 0 + 5000000 = 5000000
     expect(decoded.payload.amount).toBe('5000000')
+  })
+})
+
+describe('client-side cumulative tracking (store)', () => {
+  it('persists signed cumulative to store after signing', async () => {
+    const commitmentBytes = Buffer.from('store-persist-test')
+    mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
+
+    const store = Store.memory()
+    const method = channel({ commitmentKey: TEST_KEYPAIR, store })
+    const challenge = mockChallenge()
+
+    await method.createCredential({ challenge: challenge as any, context: {} as any })
+
+    const stored = (await store.get(`stellar:channel:client:${CHANNEL_ADDRESS}:cumulative`)) as {
+      amount: string
+    }
+    expect(stored).not.toBeNull()
+    expect(stored.amount).toBe('1000000') // 0 + 1000000
+  })
+
+  it('uses locally tracked cumulative over lower server-reported value', async () => {
+    const commitmentBytes = Buffer.from('local-over-server-test')
+    mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
+
+    const store = Store.memory()
+    // Simulate client has already committed 5000000 locally
+    await store.put(`stellar:channel:client:${CHANNEL_ADDRESS}:cumulative`, {
+      amount: '5000000',
+    })
+
+    const method = channel({ commitmentKey: TEST_KEYPAIR, store })
+    // Server reports only 2000000 (reset attack — would normally be 5000000)
+    const challenge = mockChallenge({
+      amount: '1000000',
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'stellar:testnet',
+        cumulativeAmount: '2000000', // server under-reports local state
+      },
+    })
+
+    const credential = await method.createCredential({
+      challenge: challenge as any,
+      context: {} as any,
+    })
+
+    const token = credential.replace(/^Payment\s+/, '')
+    const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
+    // Uses local (5000000) not server-reported (2000000) as base → 5000000 + 1000000 = 6000000
+    expect(decoded.payload.amount).toBe('6000000')
+  })
+
+  it('uses server-reported cumulative when no local state exists (first connection)', async () => {
+    const commitmentBytes = Buffer.from('first-connection-test')
+    mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
+
+    const store = Store.memory() // empty — no prior local state
+    const method = channel({ commitmentKey: TEST_KEYPAIR, store })
+    const challenge = mockChallenge({
+      amount: '500000',
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'stellar:testnet',
+        cumulativeAmount: '3000000', // server reports existing cumulative
+      },
+    })
+
+    const credential = await method.createCredential({
+      challenge: challenge as any,
+      context: {} as any,
+    })
+
+    const token = credential.replace(/^Payment\s+/, '')
+    const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
+    // No local state → falls back to server-reported 3000000 + 500000 = 3500000
+    expect(decoded.payload.amount).toBe('3500000')
+
+    // And persists the new cumulative for next call
+    const stored = (await store.get(`stellar:channel:client:${CHANNEL_ADDRESS}:cumulative`)) as {
+      amount: string
+    }
+    expect(stored.amount).toBe('3500000')
+  })
+
+  it('behaves identically to no-store when store is omitted', async () => {
+    const commitmentBytes = Buffer.from('no-store-compat-test')
+    mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
+
+    const method = channel({ commitmentKey: TEST_KEYPAIR }) // no store
+    const challenge = mockChallenge({
+      amount: '500000',
+      methodDetails: {
+        reference: crypto.randomUUID(),
+        network: 'stellar:testnet',
+        cumulativeAmount: '2000000',
+      },
+    })
+
+    const credential = await method.createCredential({
+      challenge: challenge as any,
+      context: {} as any,
+    })
+
+    const token = credential.replace(/^Payment\s+/, '')
+    const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
+    // Without store: trusts server-reported 2000000 + 500000 = 2500000
+    expect(decoded.payload.amount).toBe('2500000')
   })
 })
 

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -77,7 +77,7 @@ export function channel(parameters: channel.Parameters) {
       // The client tracks the last signed cumulative independently of the
       // server to prevent a rogue server from resetting the baseline.
       let localPrevious = 0n
-      const clientCumulativeKey = `stellar:channel:client:${channelAddress}:cumulative`
+      const clientCumulativeKey = `stellar:channel:client:${network}:${channelAddress}:cumulative`
       if (store) {
         const localStored = await store.get(clientCumulativeKey)
         if (localStored && typeof localStored === 'object' && 'amount' in localStored) {

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -1,5 +1,5 @@
 import { Contract, Keypair, TransactionBuilder, nativeToScVal, rpc } from '@stellar/stellar-sdk'
-import { Credential, Method } from 'mppx'
+import { Credential, Method, Store } from 'mppx'
 import { z } from 'zod/mini'
 import { DEFAULT_FEE, NETWORK_PASSPHRASE, SOROBAN_RPC_URLS } from '../../constants.js'
 import { DEFAULT_SIMULATION_TIMEOUT_MS } from '../../shared/defaults.js'
@@ -38,6 +38,7 @@ export function channel(parameters: channel.Parameters) {
     rpcUrl,
     simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
     sourceAccount,
+    store,
   } = parameters
 
   if (!commitmentKeyParam && !commitmentSecret) {
@@ -72,7 +73,24 @@ export function channel(parameters: channel.Parameters) {
         }
       }
 
-      const previousCumulative = BigInt(request.methodDetails?.cumulativeAmount ?? '0')
+      // Read locally tracked cumulative from store (if provided).
+      // The client tracks the last signed cumulative independently of the
+      // server to prevent a rogue server from resetting the baseline.
+      let localPrevious = 0n
+      const clientCumulativeKey = `stellar:channel:client:${channelAddress}:cumulative`
+      if (store) {
+        const localStored = await store.get(clientCumulativeKey)
+        if (localStored && typeof localStored === 'object' && 'amount' in localStored) {
+          localPrevious = BigInt((localStored as { amount: string }).amount)
+        }
+      }
+
+      // Take the maximum of the locally tracked baseline and the
+      // server-reported value. This prevents the server from artificially
+      // resetting the cumulative below what the client has already committed.
+      const serverReported = BigInt(request.methodDetails?.cumulativeAmount ?? '0')
+      const previousCumulative = localPrevious > serverReported ? localPrevious : serverReported
+
       const cumulativeAmount =
         context?.cumulativeAmount !== undefined
           ? BigInt(context.cumulativeAmount)
@@ -124,6 +142,12 @@ export function channel(parameters: channel.Parameters) {
       // Convert signature to hex string
       const sigHex = signature.toString('hex')
 
+      // Persist the signed cumulative amount so future calls can use the
+      // locally tracked baseline instead of trusting the server's claim.
+      if (store) {
+        await store.put(clientCumulativeKey, { amount: cumulativeAmount.toString() })
+      }
+
       onProgress?.({
         type: 'signed',
         cumulativeAmount: cumulativeAmount.toString(),
@@ -168,6 +192,16 @@ export declare namespace channel {
      * key's public key is used, which requires it to be a funded account.
      */
     sourceAccount?: string
+    /**
+     * Optional persistent store for client-side cumulative amount tracking.
+     *
+     * When provided, the client persists the last signed cumulative amount
+     * and uses it as the baseline for subsequent commitments, taking the
+     * maximum of the locally tracked value and the server-reported value.
+     * This prevents a malicious or compromised server from resetting the
+     * client's cumulative baseline to inflate the signed commitment.
+     */
+    store?: Store.Store
     /** Callback invoked at each lifecycle stage. */
     onProgress?: (event: ProgressEvent) => void
   }

--- a/sdk/src/channel/integration.test.ts
+++ b/sdk/src/channel/integration.test.ts
@@ -31,6 +31,7 @@ describe('channel server creation', () => {
     const method = serverChannel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
+      store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
     expect(method.intent).toBe('channel')
@@ -45,6 +46,7 @@ describe('channel server creation', () => {
         serverChannel({
           channel: CHANNEL_ADDRESS,
           commitmentKey: COMMITMENT_KEY.publicKey(),
+          store: Store.memory(),
         }),
       ],
     })

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -217,6 +217,7 @@ describe('stellar server channel', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
+      store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
     expect(method.intent).toBe('channel')
@@ -226,11 +227,12 @@ describe('stellar server channel', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
+      store: Store.memory(),
     })
     expect(typeof method.verify).toBe('function')
   })
 
-  it('accepts store for replay protection', () => {
+  it('requires store for replay protection and cumulative tracking', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
@@ -244,6 +246,7 @@ describe('stellar server channel', () => {
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
       network: 'stellar:pubnet',
+      store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
   })
@@ -253,6 +256,7 @@ describe('stellar server channel', () => {
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
       rpcUrl: 'https://custom.rpc.example.com',
+      store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
   })
@@ -261,6 +265,7 @@ describe('stellar server channel', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
   })
@@ -270,6 +275,7 @@ describe('stellar server channel', () => {
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
       decimals: 6,
+      store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
   })
@@ -279,6 +285,7 @@ describe('stellar server channel', () => {
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY.publicKey(),
       sourceAccount: Keypair.random().publicKey(),
+      store: Store.memory(),
     })
     expect(method.name).toBe('stellar')
   })
@@ -315,6 +322,7 @@ describe('stellar server channel verification', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -359,6 +367,7 @@ describe('stellar server channel verification', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -404,6 +413,7 @@ describe('stellar server channel verification', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -424,6 +434,7 @@ describe('stellar server channel verification', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -448,6 +459,7 @@ describe('stellar server channel verification', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -564,6 +576,7 @@ describe('stellar server channel verification', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -597,6 +610,7 @@ describe('stellar server channel dispute detection', () => {
       commitmentKey: COMMITMENT_KEY,
       checkOnChainState: true,
       sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+      store: Store.memory(),
     })
 
     await expect(
@@ -636,6 +650,7 @@ describe('stellar server channel dispute detection', () => {
       checkOnChainState: true,
       sourceAccount: MOCK_SOURCE_KEY.publicKey(),
       onDisputeDetected,
+      store: Store.memory(),
     })
 
     const receipt = await method.verify({
@@ -662,6 +677,7 @@ describe('stellar server channel dispute detection', () => {
       commitmentKey: COMMITMENT_KEY,
       checkOnChainState: true,
       sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+      store: Store.memory(),
     })
 
     // NM-005: Fail closed — on-chain check failure now rejects the voucher
@@ -733,6 +749,7 @@ describe('stellar server channel dispute detection', () => {
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
       // checkOnChainState defaults to false
+      store: Store.memory(),
     })
 
     const receipt = await method.verify({
@@ -754,6 +771,7 @@ describe('stellar server channel dispute detection', () => {
       commitmentKey: COMMITMENT_KEY,
       checkOnChainState: true,
       // sourceAccount intentionally omitted
+      store: Store.memory(),
     })
 
     await expect(
@@ -812,6 +830,7 @@ describe('stellar server channel dispute detection', () => {
       commitmentKey: COMMITMENT_KEY,
       checkOnChainState: true,
       sourceAccount: MOCK_SOURCE_KEY.publicKey(),
+      store: Store.memory(),
     })
 
     await expect(
@@ -834,6 +853,7 @@ describe('stellar server channel open action', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -854,6 +874,7 @@ describe('stellar server channel open action', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -877,6 +898,7 @@ describe('stellar server channel open action', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(
@@ -941,6 +963,7 @@ describe('stellar server channel open action', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,
       commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
     })
 
     await expect(

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -213,6 +213,15 @@ function makeSignedOpenCredential(opts: {
 }
 
 describe('stellar server channel', () => {
+  it('throws at construction when store is omitted (JS runtime guard)', () => {
+    expect(() =>
+      channel({
+        channel: CHANNEL_ADDRESS,
+        commitmentKey: COMMITMENT_KEY.publicKey(),
+      } as any),
+    ).toThrow('store is required')
+  })
+
   it('creates a server method with correct name and intent', () => {
     const method = channel({
       channel: CHANNEL_ADDRESS,

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -63,6 +63,13 @@ const LOG_PREFIX = '[stellar:channel]'
 const STORE_PREFIX = 'stellar:channel'
 
 export function channel(parameters: channel.Parameters) {
+  if (!parameters.store) {
+    throw new ChannelVerificationError(
+      `${LOG_PREFIX} A store is required for channel mode. Provide a Store instance for replay protection, cumulative tracking, and channel lifecycle state.`,
+      {},
+    )
+  }
+
   const {
     channel: channelAddress,
     checkOnChainState = false,

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -107,6 +107,10 @@ export function channel(parameters: channel.Parameters) {
   // read the same cumulative amount, both pass, and only one write wins.
   let verifyLock: Promise<unknown> = Promise.resolve()
 
+  logger.info(
+    `${LOG_PREFIX} Initialized. Multi-process deployments require the store to provide atomic put-if-absent semantics for replay protection.`,
+  )
+
   return Method.toServer(ChannelMethod, {
     defaults: {
       channel: channelAddress,
@@ -114,11 +118,9 @@ export function channel(parameters: channel.Parameters) {
     async request({ request }) {
       // Retrieve current cumulative amount from store
       let currentCumulative = '0'
-      if (store) {
-        const stored = await store.get(cumulativeKey)
-        if (stored && typeof stored === 'object' && 'amount' in stored) {
-          currentCumulative = (stored as { amount: string }).amount
-        }
+      const stored = await store.get(cumulativeKey)
+      if (stored && typeof stored === 'object' && 'amount' in stored) {
+        currentCumulative = (stored as { amount: string }).amount
       }
 
       return {
@@ -154,17 +156,15 @@ export function channel(parameters: channel.Parameters) {
 
     // NM-001: Reject credentials once the channel has been closed on-chain.
     // Applied to all actions including 'open'.
-    if (store) {
-      const closed = await store.get(`${STORE_PREFIX}:closed:${channelAddress}`)
-      if (closed) {
-        logger.warn(`${LOG_PREFIX} Rejecting credential — channel already closed`, {
-          channel: channelAddress,
-        })
-        throw new ChannelVerificationError(
-          `${LOG_PREFIX} Channel has been closed. No further credentials accepted.`,
-          { channel: channelAddress },
-        )
-      }
+    const closed = await store.get(`${STORE_PREFIX}:closed:${channelAddress}`)
+    if (closed) {
+      logger.warn(`${LOG_PREFIX} Rejecting credential — channel already closed`, {
+        channel: channelAddress,
+      })
+      throw new ChannelVerificationError(
+        `${LOG_PREFIX} Channel has been closed. No further credentials accepted.`,
+        { channel: channelAddress },
+      )
     }
 
     // Replay protection — applied to all actions including 'open'.
@@ -173,14 +173,12 @@ export function channel(parameters: channel.Parameters) {
     // deployments MUST use a store with atomic put-if-absent semantics.
     // Check early but only mark as used AFTER successful verification to
     // avoid permanently burning a challenge on transient failures.
-    const challengeStoreKey = store ? `${STORE_PREFIX}:challenge:${challenge.id}` : undefined
-    if (store && challengeStoreKey) {
-      const existing = await store.get(challengeStoreKey)
-      if (existing) {
-        throw new ChannelVerificationError('Challenge already used. Replay rejected.', {
-          channel: channelAddress,
-        })
-      }
+    const challengeStoreKey = `${STORE_PREFIX}:challenge:${challenge.id}`
+    const existingChallenge = await store.get(challengeStoreKey)
+    if (existingChallenge) {
+      throw new ChannelVerificationError('Challenge already used. Replay rejected.', {
+        channel: channelAddress,
+      })
     }
 
     // Dispatch open action to its own handler — it has completely
@@ -296,11 +294,9 @@ export function channel(parameters: channel.Parameters) {
 
     // Retrieve the previous cumulative amount
     let previousCumulative = 0n
-    if (store) {
-      const stored = await store.get(cumulativeKey)
-      if (stored && typeof stored === 'object' && 'amount' in stored) {
-        previousCumulative = BigInt((stored as { amount: string }).amount)
-      }
+    const storedCumulative = await store.get(cumulativeKey)
+    if (storedCumulative && typeof storedCumulative === 'object' && 'amount' in storedCumulative) {
+      previousCumulative = BigInt((storedCumulative as { amount: string }).amount)
     }
 
     // Reject zero or negative requested amounts
@@ -393,11 +389,9 @@ export function channel(parameters: channel.Parameters) {
     }
 
     // Update cumulative amount in store
-    if (store) {
-      await store.put(cumulativeKey, {
-        amount: commitmentAmount.toString(),
-      })
-    }
+    await store.put(cumulativeKey, {
+      amount: commitmentAmount.toString(),
+    })
 
     // Dispatch on action
     if (action === 'close') {
@@ -463,18 +457,14 @@ export function channel(parameters: channel.Parameters) {
 
       // Mark channel as closed in store
       logger.debug(`${LOG_PREFIX} Channel closed, marking in store`)
-      if (store) {
-        await store.put(`${STORE_PREFIX}:closed:${channelAddress}`, {
-          closedAt: new Date().toISOString(),
-          txHash: sendResult.hash,
-          amount: commitmentAmount.toString(),
-        })
-      }
+      await store.put(`${STORE_PREFIX}:closed:${channelAddress}`, {
+        closedAt: new Date().toISOString(),
+        txHash: sendResult.hash,
+        amount: commitmentAmount.toString(),
+      })
 
       // Mark challenge as used only after successful close settlement
-      if (store && challengeStoreKey) {
-        await store.put(challengeStoreKey, { usedAt: new Date().toISOString() })
-      }
+      await store.put(challengeStoreKey, { usedAt: new Date().toISOString() })
 
       return Receipt.from({
         method: 'stellar',
@@ -486,9 +476,7 @@ export function channel(parameters: channel.Parameters) {
     }
 
     // Mark challenge as used only after successful voucher verification
-    if (store && challengeStoreKey) {
-      await store.put(challengeStoreKey, { usedAt: new Date().toISOString() })
-    }
+    await store.put(challengeStoreKey, { usedAt: new Date().toISOString() })
 
     return Receipt.from({
       method: 'stellar',
@@ -505,7 +493,7 @@ export function channel(parameters: channel.Parameters) {
    * broadcasts the transaction, waits for confirmation, then initialises
    * the cumulative amount in the store.
    */
-  async function doVerifyOpen(credential: any, challengeStoreKey: string | undefined) {
+  async function doVerifyOpen(credential: any, challengeStoreKey: string) {
     const { challenge } = credential
     const { externalId } = challenge.request
     const payload = credential.payload
@@ -568,14 +556,12 @@ export function channel(parameters: channel.Parameters) {
     }
 
     // Reject if the channel is already opened (cumulativeKey already set).
-    if (store) {
-      const existing = await store.get(cumulativeKey)
-      if (existing) {
-        throw new ChannelVerificationError(
-          `${LOG_PREFIX} Channel is already open. Cannot replay an open credential.`,
-          { channel: channelAddress },
-        )
-      }
+    const existingChannel = await store.get(cumulativeKey)
+    if (existingChannel) {
+      throw new ChannelVerificationError(
+        `${LOG_PREFIX} Channel is already open. Cannot replay an open credential.`,
+        { channel: channelAddress },
+      )
     }
 
     // Verify the initial commitment signature via prepare_commitment simulation
@@ -668,16 +654,12 @@ export function channel(parameters: channel.Parameters) {
     }
 
     // Initialise cumulative amount in the store
-    if (store) {
-      await store.put(cumulativeKey, {
-        amount: commitmentAmount.toString(),
-      })
-    }
+    await store.put(cumulativeKey, {
+      amount: commitmentAmount.toString(),
+    })
 
     // Mark challenge as used only after successful open settlement
-    if (store && challengeStoreKey) {
-      await store.put(challengeStoreKey, { usedAt: new Date().toISOString() })
-    }
+    await store.put(challengeStoreKey, { usedAt: new Date().toISOString() })
 
     return Receipt.from({
       method: 'stellar',
@@ -860,8 +842,20 @@ export declare namespace channel {
      * key's public key is used, which requires it to be a funded account.
      */
     sourceAccount?: string
-    /** Store for replay protection and cumulative amount tracking. */
-    store?: Store.Store
+    /**
+     * Persistent store for replay protection, cumulative amount tracking,
+     * and channel lifecycle state (open/closed).
+     *
+     * Required — the channel security model depends entirely on this store.
+     * Without it, replay attacks, non-monotonic commitments, and post-close
+     * voucher acceptance are all possible.
+     *
+     * For multi-process deployments (e.g., multiple Node.js pods behind a
+     * load balancer), the store must provide atomic put-if-absent semantics
+     * to prevent TOCTOU races in replay protection. The in-process
+     * `verifyLock` serializes calls within a single process only.
+     */
+    store: Store.Store
     /** Logger for debug/warn messages. @default noopLogger */
     logger?: Logger
   }

--- a/sdk/src/charge/server/Charge.test.ts
+++ b/sdk/src/charge/server/Charge.test.ts
@@ -252,6 +252,95 @@ describe('charge hash+feePayer rejection', () => {
   })
 })
 
+describe('charge push-mode verification (NM-001 regression)', () => {
+  it('rejects hash whose on-chain tx has wrong amount (NM-001)', async () => {
+    // Before the fix, verifySacTransfer swallowed all errors — any successful on-chain tx
+    // would be accepted as payment. Now it must throw on wrong transfer parameters.
+    const wrongAmountTx = buildTransferTx({
+      source: PAYER.publicKey(),
+      from: PAYER.publicKey(),
+      to: RECIPIENT,
+      amount: 5000000n, // wrong — challenge expects 10000000
+      currency: USDC_SAC_TESTNET,
+    })
+    wrongAmountTx.sign(PAYER)
+
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: wrongAmountTx.toXDR(),
+    })
+
+    const cred = makeHashCredential({ hash: 'wrong-amount-tx-hash' })
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('matching SAC transfer invocation')
+  })
+
+  it('rejects hash whose on-chain tx transfers to wrong recipient (NM-001)', async () => {
+    const wrongRecipient = Keypair.random().publicKey()
+    const tx = buildTransferTx({
+      source: PAYER.publicKey(),
+      from: PAYER.publicKey(),
+      to: wrongRecipient,
+      amount: 10000000n,
+      currency: USDC_SAC_TESTNET,
+    })
+    tx.sign(PAYER)
+
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: tx.toXDR(),
+    })
+
+    const cred = makeHashCredential({ hash: 'wrong-recipient-tx-hash' })
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('matching SAC transfer invocation')
+  })
+
+  it('rejects hash whose on-chain tx uses wrong currency (NM-001)', async () => {
+    const wrongCurrency = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
+    const tx = buildTransferTx({
+      source: PAYER.publicKey(),
+      from: PAYER.publicKey(),
+      to: RECIPIENT,
+      amount: 10000000n,
+      currency: wrongCurrency, // wrong SAC contract
+    })
+    tx.sign(PAYER)
+
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: tx.toXDR(),
+    })
+
+    const cred = makeHashCredential({ hash: 'wrong-currency-tx-hash' })
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('matching SAC transfer invocation')
+  })
+
+  it('rejects hash when on-chain tx has no envelopeXdr (NM-001)', async () => {
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: undefined,
+    })
+
+    const cred = makeHashCredential({ hash: 'no-envelope-hash' })
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('missing envelope XDR')
+  })
+})
+
 describe('charge tx hash dedup', () => {
   it('rejects a second verify with the same tx hash', async () => {
     mockGetTransaction.mockResolvedValue({

--- a/sdk/src/charge/server/Charge.test.ts
+++ b/sdk/src/charge/server/Charge.test.ts
@@ -252,6 +252,123 @@ describe('charge hash+feePayer rejection', () => {
   })
 })
 
+describe('charge push-mode sender verification (hash-theft attack prevention)', () => {
+  it('rejects hash where the on-chain `from` does not match the credential source', async () => {
+    // Attack: attacker steals a client's tx hash and submits it with their own challenge.
+    // The tx transfers from LEGITIMATE_CLIENT but the attacker's credential claims
+    // source = ATTACKER. The server must compare args[0] against credential.source.
+    const legitimateClient = Keypair.random()
+    const tx = buildTransferTx({
+      source: legitimateClient.publicKey(),
+      from: legitimateClient.publicKey(),
+      to: RECIPIENT,
+      amount: 10000000n,
+      currency: USDC_SAC_TESTNET,
+    })
+    tx.sign(legitimateClient)
+
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: tx.toXDR(),
+    })
+
+    const attackerKey = Keypair.random().publicKey()
+    const challenge = Challenge.from({
+      id: `test-${crypto.randomUUID()}`,
+      realm: 'localhost',
+      method: 'stellar',
+      intent: 'charge',
+      request: {
+        amount: '10000000',
+        currency: USDC_SAC_TESTNET,
+        recipient: RECIPIENT,
+        methodDetails: { network: 'stellar:testnet' },
+      },
+    })
+    // Attacker's credential claims their own key as source
+    const cred = Object.assign(
+      Credential.from({ challenge, payload: { type: 'hash', hash: 'stolen-hash' } }),
+      { source: `did:pkh:stellar:testnet:${attackerKey}` },
+    )
+
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('matching SAC transfer invocation')
+  })
+
+  it('accepts hash where the on-chain `from` matches the credential source', async () => {
+    const client = PAYER // PAYER key defined in test scope
+    const tx = buildTransferTx({
+      source: client.publicKey(),
+      from: client.publicKey(),
+      to: RECIPIENT,
+      amount: 10000000n,
+      currency: USDC_SAC_TESTNET,
+    })
+    tx.sign(client)
+
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: tx.toXDR(),
+    })
+
+    const challenge = Challenge.from({
+      id: `test-${crypto.randomUUID()}`,
+      realm: 'localhost',
+      method: 'stellar',
+      intent: 'charge',
+      request: {
+        amount: '10000000',
+        currency: USDC_SAC_TESTNET,
+        recipient: RECIPIENT,
+        methodDetails: { network: 'stellar:testnet' },
+      },
+    })
+    // Credential source matches the actual `from` in the tx
+    const cred = Object.assign(
+      Credential.from({ challenge, payload: { type: 'hash', hash: 'legit-hash' } }),
+      { source: `did:pkh:stellar:testnet:${client.publicKey()}` },
+    )
+
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    const receipt = await method.verify({
+      credential: cred as any,
+      request: cred.challenge.request,
+    })
+    expect(receipt.status).toBe('success')
+  })
+
+  it('skips from-check when credential has no source (backward compat)', async () => {
+    // Credentials without source still pass — graceful degradation.
+    const tx = buildTransferTx({
+      source: PAYER.publicKey(),
+      from: PAYER.publicKey(),
+      to: RECIPIENT,
+      amount: 10000000n,
+      currency: USDC_SAC_TESTNET,
+    })
+    tx.sign(PAYER)
+
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: tx.toXDR(),
+    })
+
+    const cred = makeHashCredential({ hash: 'no-source-hash' }) // no source field
+
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    const receipt = await method.verify({
+      credential: cred as any,
+      request: cred.challenge.request,
+    })
+    expect(receipt.status).toBe('success')
+  })
+})
+
 describe('charge push-mode verification (NM-001 regression)', () => {
   it('rejects hash whose on-chain tx has wrong amount (NM-001)', async () => {
     // Before the fix, verifySacTransfer swallowed all errors — any successful on-chain tx
@@ -438,6 +555,34 @@ function makeTransactionCredential(txXdr: string, challengeAmount: string = '100
 }
 
 describe('charge transaction verification', () => {
+  it('rejects transaction where from address does not match credential source', async () => {
+    const actualPayer = Keypair.random()
+    const tx = buildTransferTx({
+      source: actualPayer.publicKey(),
+      from: actualPayer.publicKey(), // tx was built by actualPayer
+      to: RECIPIENT,
+      amount: 10000000n,
+      currency: USDC_SAC_TESTNET,
+    })
+    tx.sign(actualPayer)
+
+    mockSimulateTransaction.mockResolvedValueOnce({
+      result: { retval: null },
+      events: [],
+      transactionData: 'mock',
+    })
+
+    // Credential claims PAYER as source, but tx `from` is actualPayer — mismatch
+    const cred = Object.assign(makeTransactionCredential(tx.toXDR()), {
+      source: `did:pkh:stellar:testnet:${PAYER.publicKey()}`,
+    })
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('matching SAC transfer invocation')
+  })
+
   it('rejects transaction with wrong recipient', async () => {
     const wrongRecipient = Keypair.random().publicKey()
     const tx = buildTransferTx({

--- a/sdk/src/charge/server/Charge.test.ts
+++ b/sdk/src/charge/server/Charge.test.ts
@@ -362,11 +362,7 @@ describe('charge push-mode sender verification (hash-theft attack prevention)', 
   })
 
   it('rejects credential with malformed source DID', async () => {
-    mockGetTransaction.mockResolvedValueOnce({
-      status: 'SUCCESS',
-      envelopeXdr: 'unused',
-    })
-
+    mockGetTransaction.mockResolvedValueOnce({ status: 'SUCCESS', envelopeXdr: 'unused' })
     const challenge = Challenge.from({
       id: `test-${crypto.randomUUID()}`,
       realm: 'localhost',
@@ -389,6 +385,58 @@ describe('charge push-mode sender verification (hash-theft attack prevention)', 
     await expect(
       method.verify({ credential: cred as any, request: cred.challenge.request }),
     ).rejects.toThrow('invalid format')
+  })
+
+  it('rejects source DID with non-stellar namespace', async () => {
+    mockGetTransaction.mockResolvedValueOnce({ status: 'SUCCESS', envelopeXdr: 'unused' })
+    const challenge = Challenge.from({
+      id: `test-${crypto.randomUUID()}`,
+      realm: 'localhost',
+      method: 'stellar',
+      intent: 'charge',
+      request: {
+        amount: '10000000',
+        currency: USDC_SAC_TESTNET,
+        recipient: RECIPIENT,
+        methodDetails: { network: 'stellar:testnet' },
+      },
+    })
+    const cred = Object.assign(
+      Credential.from({ challenge, payload: { type: 'hash', hash: 'eip155-hash' } }),
+      { source: `did:pkh:eip155:1:0xabc123` },
+    )
+
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('invalid format')
+  })
+
+  it('rejects source DID with invalid Stellar public key', async () => {
+    mockGetTransaction.mockResolvedValueOnce({ status: 'SUCCESS', envelopeXdr: 'unused' })
+    const challenge = Challenge.from({
+      id: `test-${crypto.randomUUID()}`,
+      realm: 'localhost',
+      method: 'stellar',
+      intent: 'charge',
+      request: {
+        amount: '10000000',
+        currency: USDC_SAC_TESTNET,
+        recipient: RECIPIENT,
+        methodDetails: { network: 'stellar:testnet' },
+      },
+    })
+    const cred = Object.assign(
+      Credential.from({ challenge, payload: { type: 'hash', hash: 'bad-key-hash' } }),
+      { source: 'did:pkh:stellar:testnet:NOT_A_VALID_KEY' },
+    )
+
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('invalid Stellar public key')
   })
 })
 

--- a/sdk/src/charge/server/Charge.test.ts
+++ b/sdk/src/charge/server/Charge.test.ts
@@ -197,7 +197,7 @@ describe('charge request transform', () => {
 // Transaction hash dedup tests (hash flow with mocked RPC)
 // ---------------------------------------------------------------------------
 
-function makeHashCredential(opts: { hash: string; challengeId?: string }) {
+function makeHashCredential(opts: { hash: string; challengeId?: string; source?: string }) {
   const challenge = Challenge.from({
     id: opts.challengeId ?? `test-${crypto.randomUUID()}`,
     realm: 'localhost',
@@ -212,10 +212,15 @@ function makeHashCredential(opts: { hash: string; challengeId?: string }) {
       },
     },
   })
-  return Credential.from({
+  const cred = Credential.from({
     challenge,
     payload: { type: 'hash', hash: opts.hash },
   })
+  // source is explicitly settable; omitting it tests the "no source" rejection path
+  if (opts.source !== undefined) {
+    return Object.assign(cred, { source: opts.source })
+  }
+  return cred
 }
 
 describe('charge hash+feePayer rejection', () => {
@@ -341,31 +346,49 @@ describe('charge push-mode sender verification (hash-theft attack prevention)', 
     expect(receipt.status).toBe('success')
   })
 
-  it('skips from-check when credential has no source (backward compat)', async () => {
-    // Credentials without source still pass — graceful degradation.
-    const tx = buildTransferTx({
-      source: PAYER.publicKey(),
-      from: PAYER.publicKey(),
-      to: RECIPIENT,
-      amount: 10000000n,
-      currency: USDC_SAC_TESTNET,
-    })
-    tx.sign(PAYER)
-
+  it('rejects credential with no source (source is mandatory)', async () => {
     mockGetTransaction.mockResolvedValueOnce({
       status: 'SUCCESS',
-      envelopeXdr: tx.toXDR(),
+      envelopeXdr: 'unused',
     })
 
-    const cred = makeHashCredential({ hash: 'no-source-hash' }) // no source field
+    const cred = makeHashCredential({ hash: 'no-source-hash' }) // source field absent
 
     const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
 
-    const receipt = await method.verify({
-      credential: cred as any,
-      request: cred.challenge.request,
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('Credential source is required')
+  })
+
+  it('rejects credential with malformed source DID', async () => {
+    mockGetTransaction.mockResolvedValueOnce({
+      status: 'SUCCESS',
+      envelopeXdr: 'unused',
     })
-    expect(receipt.status).toBe('success')
+
+    const challenge = Challenge.from({
+      id: `test-${crypto.randomUUID()}`,
+      realm: 'localhost',
+      method: 'stellar',
+      intent: 'charge',
+      request: {
+        amount: '10000000',
+        currency: USDC_SAC_TESTNET,
+        recipient: RECIPIENT,
+        methodDetails: { network: 'stellar:testnet' },
+      },
+    })
+    const cred = Object.assign(
+      Credential.from({ challenge, payload: { type: 'hash', hash: 'bad-did-hash' } }),
+      { source: 'not-a-valid-did' },
+    )
+
+    const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
+
+    await expect(
+      method.verify({ credential: cred as any, request: cred.challenge.request }),
+    ).rejects.toThrow('invalid format')
   })
 })
 
@@ -387,7 +410,10 @@ describe('charge push-mode verification (NM-001 regression)', () => {
       envelopeXdr: wrongAmountTx.toXDR(),
     })
 
-    const cred = makeHashCredential({ hash: 'wrong-amount-tx-hash' })
+    const cred = makeHashCredential({
+      hash: 'wrong-amount-tx-hash',
+      source: `did:pkh:stellar:testnet:${PAYER.publicKey()}`,
+    })
     const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
 
     await expect(
@@ -411,7 +437,10 @@ describe('charge push-mode verification (NM-001 regression)', () => {
       envelopeXdr: tx.toXDR(),
     })
 
-    const cred = makeHashCredential({ hash: 'wrong-recipient-tx-hash' })
+    const cred = makeHashCredential({
+      hash: 'wrong-recipient-tx-hash',
+      source: `did:pkh:stellar:testnet:${PAYER.publicKey()}`,
+    })
     const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
 
     await expect(
@@ -435,7 +464,10 @@ describe('charge push-mode verification (NM-001 regression)', () => {
       envelopeXdr: tx.toXDR(),
     })
 
-    const cred = makeHashCredential({ hash: 'wrong-currency-tx-hash' })
+    const cred = makeHashCredential({
+      hash: 'wrong-currency-tx-hash',
+      source: `did:pkh:stellar:testnet:${PAYER.publicKey()}`,
+    })
     const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
 
     await expect(
@@ -449,7 +481,10 @@ describe('charge push-mode verification (NM-001 regression)', () => {
       envelopeXdr: undefined,
     })
 
-    const cred = makeHashCredential({ hash: 'no-envelope-hash' })
+    const cred = makeHashCredential({
+      hash: 'no-envelope-hash',
+      source: `did:pkh:stellar:testnet:${PAYER.publicKey()}`,
+    })
     const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
 
     await expect(
@@ -533,7 +568,11 @@ function buildTransferTx(opts: {
     .build()
 }
 
-function makeTransactionCredential(txXdr: string, challengeAmount: string = '10000000') {
+function makeTransactionCredential(
+  txXdr: string,
+  challengeAmount: string = '10000000',
+  source: string = `did:pkh:stellar:testnet:${PAYER.publicKey()}`,
+) {
   const challenge = Challenge.from({
     id: `test-${crypto.randomUUID()}`,
     realm: 'localhost',
@@ -548,10 +587,10 @@ function makeTransactionCredential(txXdr: string, challengeAmount: string = '100
       },
     },
   })
-  return Credential.from({
-    challenge,
-    payload: { type: 'transaction', transaction: txXdr },
-  })
+  return Object.assign(
+    Credential.from({ challenge, payload: { type: 'transaction', transaction: txXdr } }),
+    { source },
+  )
 }
 
 describe('charge transaction verification', () => {
@@ -735,10 +774,10 @@ describe('charge transaction verification', () => {
         methodDetails: { network: 'stellar:testnet' },
       },
     })
-    const cred = Credential.from({
-      challenge,
-      payload: { type: 'transaction', transaction: tx.toXDR() },
-    })
+    const cred = Object.assign(
+      Credential.from({ challenge, payload: { type: 'transaction', transaction: tx.toXDR() } }),
+      { source: `did:pkh:stellar:testnet:${PAYER.publicKey()}` },
+    )
 
     // First call succeeds
     await method.verify({ credential: cred as any, request: cred.challenge.request })
@@ -783,10 +822,10 @@ describe('charge transaction verification', () => {
         methodDetails: { network: 'stellar:testnet' },
       },
     })
-    const cred = Credential.from({
-      challenge,
-      payload: { type: 'transaction', transaction: tx.toXDR() },
-    })
+    const cred = Object.assign(
+      Credential.from({ challenge, payload: { type: 'transaction', transaction: tx.toXDR() } }),
+      { source: `did:pkh:stellar:testnet:${PAYER.publicKey()}` },
+    )
 
     const method = charge({ recipient: RECIPIENT, currency: USDC_SAC_TESTNET })
 

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -553,6 +553,7 @@ function verifyFromRawOps(
     throw new PaymentVerificationError(
       `${LOG_PREFIX} Transaction does not contain a matching SAC transfer invocation.`,
       {
+        from: expected.from,
         currency: expected.currency,
         recipient: expected.recipient,
         amount: expected.amount.toString(),
@@ -713,8 +714,23 @@ function publicKeyFromDID(source: unknown): string {
   }
   const parts = source.split(':')
   // did : pkh : stellar : {network} : {pubkey}
-  if (parts.length >= 4 && parts[0] === 'did' && parts[1] === 'pkh') {
-    return parts[parts.length - 1]
+  if (
+    parts.length === 5 &&
+    parts[0] === 'did' &&
+    parts[1] === 'pkh' &&
+    parts[2] === 'stellar' &&
+    parts[3] // non-empty network
+  ) {
+    const pubKey = parts[4]
+    try {
+      Keypair.fromPublicKey(pubKey)
+    } catch {
+      throw new PaymentVerificationError(
+        `${LOG_PREFIX} Credential source contains an invalid Stellar public key.`,
+        { source },
+      )
+    }
+    return pubKey
   }
   throw new PaymentVerificationError(
     `${LOG_PREFIX} Credential source has invalid format — expected did:pkh:stellar:{network}:{pubkey}.`,

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -161,12 +161,17 @@ export function charge(parameters: charge.Parameters) {
           timeoutMs: pollTimeoutMs,
         })
 
+        // Extract the payer's public key from the credential DID to verify
+        // the on-chain transfer's `from` address matches the credential's
+        // claimed identity, preventing hash-theft attacks against clients.
+        const expectedFrom = publicKeyFromDID(credential.source)
         verifySacTransfer(
           txResult,
           {
             amount: expectedAmount,
             currency: expectedCurrency,
             recipient: expectedRecipient,
+            from: expectedFrom,
           },
           networkPassphrase,
         )
@@ -195,10 +200,12 @@ export function charge(parameters: charge.Parameters) {
 
         verifyExactlyOneInvokeOp(tx)
 
+        const expectedFrom = publicKeyFromDID(credential.source)
         verifySacInvocation(tx, {
           amount: expectedAmount,
           currency: expectedCurrency,
           recipient: expectedRecipient,
+          from: expectedFrom,
         })
 
         let txToSubmit: Transaction | FeeBumpTransaction = parsed as
@@ -250,6 +257,7 @@ export function charge(parameters: charge.Parameters) {
             expectedCurrency,
             expectedRecipient,
             signerKeypair.publicKey(),
+            expectedFrom,
           )
 
           rebuiltTx.sign(signerKeypair)
@@ -286,6 +294,7 @@ export function charge(parameters: charge.Parameters) {
             expectedCurrency,
             expectedRecipient,
             signerKeypair?.publicKey(),
+            expectedFrom,
           )
         }
 
@@ -356,6 +365,7 @@ export function charge(parameters: charge.Parameters) {
     expectedCurrency: string,
     expectedRecipient: string,
     serverAddress: string | undefined,
+    expectedFrom: string | undefined,
   ) {
     let simResponse: rpc.Api.SimulateTransactionSuccessResponse
     try {
@@ -379,6 +389,7 @@ export function charge(parameters: charge.Parameters) {
         expectedCurrency,
         expectedRecipient,
         serverAddress,
+        expectedFrom,
       )
     }
   }
@@ -487,14 +498,14 @@ function verifyExactlyOneInvokeOp(tx: Transaction) {
 
 function verifySacInvocation(
   tx: Transaction,
-  expected: { amount: bigint; currency: string; recipient: string },
+  expected: { amount: bigint; currency: string; recipient: string; from?: string },
 ) {
   verifyFromRawOps(tx, expected)
 }
 
 function verifyFromRawOps(
   tx: Transaction,
-  expected: { amount: bigint; currency: string; recipient: string },
+  expected: { amount: bigint; currency: string; recipient: string; from?: string },
 ) {
   let found = false
   const xdrEnvelope = tx.toXDR()
@@ -522,6 +533,14 @@ function verifyFromRawOps(
     if (contractAddress !== expected.currency) continue
     if (args.length < 3) continue
 
+    // Verify the sender matches the credential's claimed identity.
+    // Prevents a third party from stealing a tx hash and claiming payment
+    // that was funded by someone else.
+    if (expected.from !== undefined) {
+      const fromAddress = Address.fromScVal(args[0]).toString()
+      if (fromAddress !== expected.from) continue
+    }
+
     const toAddress = Address.fromScVal(args[1]).toString()
     if (toAddress !== expected.recipient) continue
 
@@ -546,7 +565,7 @@ function verifyFromRawOps(
 
 function verifySacTransfer(
   txResult: rpc.Api.GetSuccessfulTransactionResponse,
-  expected: { amount: bigint; currency: string; recipient: string },
+  expected: { amount: bigint; currency: string; recipient: string; from?: string },
   networkPassphrase: string,
 ) {
   if (!txResult.envelopeXdr) {
@@ -596,6 +615,7 @@ function validateSimulationEvents(
   expectedCurrency: string,
   expectedRecipient: string,
   serverAddress: string | undefined,
+  expectedFrom: string | undefined,
 ) {
   const transferEvents: Array<{ from: string; to: string; amount: bigint; contract: string }> = []
 
@@ -644,7 +664,8 @@ function validateSimulationEvents(
   if (
     transfer.to !== expectedRecipient ||
     transfer.amount !== expectedAmount ||
-    transfer.contract !== expectedCurrency
+    transfer.contract !== expectedCurrency ||
+    (expectedFrom !== undefined && transfer.from !== expectedFrom)
   ) {
     throw new PaymentVerificationError(
       `${LOG_PREFIX} Simulation transfer event does not match expected parameters.`,
@@ -652,6 +673,7 @@ function validateSimulationEvents(
         expectedRecipient,
         expectedAmount: expectedAmount.toString(),
         expectedCurrency,
+        ...(expectedFrom !== undefined ? { expectedFrom } : {}),
       },
     )
   }
@@ -668,6 +690,29 @@ function validateSimulationEvents(
       )
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Identity helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the Stellar public key from a `did:pkh` DID string.
+ *
+ * Format: `did:pkh:stellar:{network}:{G...publicKey}`
+ *
+ * Returns `undefined` when the source is absent or in an unexpected format,
+ * in which case the `from` check is skipped (graceful degradation for
+ * credentials produced without a source field).
+ */
+function publicKeyFromDID(source: unknown): string | undefined {
+  if (typeof source !== 'string') return undefined
+  const parts = source.split(':')
+  // did : pkh : stellar : {network} : {pubkey}
+  if (parts.length >= 4 && parts[0] === 'did' && parts[1] === 'pkh') {
+    return parts[parts.length - 1]
+  }
+  return undefined
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/src/charge/server/Charge.ts
+++ b/sdk/src/charge/server/Charge.ts
@@ -365,7 +365,7 @@ export function charge(parameters: charge.Parameters) {
     expectedCurrency: string,
     expectedRecipient: string,
     serverAddress: string | undefined,
-    expectedFrom: string | undefined,
+    expectedFrom: string,
   ) {
     let simResponse: rpc.Api.SimulateTransactionSuccessResponse
     try {
@@ -498,14 +498,14 @@ function verifyExactlyOneInvokeOp(tx: Transaction) {
 
 function verifySacInvocation(
   tx: Transaction,
-  expected: { amount: bigint; currency: string; recipient: string; from?: string },
+  expected: { amount: bigint; currency: string; recipient: string; from: string },
 ) {
   verifyFromRawOps(tx, expected)
 }
 
 function verifyFromRawOps(
   tx: Transaction,
-  expected: { amount: bigint; currency: string; recipient: string; from?: string },
+  expected: { amount: bigint; currency: string; recipient: string; from: string },
 ) {
   let found = false
   const xdrEnvelope = tx.toXDR()
@@ -536,10 +536,8 @@ function verifyFromRawOps(
     // Verify the sender matches the credential's claimed identity.
     // Prevents a third party from stealing a tx hash and claiming payment
     // that was funded by someone else.
-    if (expected.from !== undefined) {
-      const fromAddress = Address.fromScVal(args[0]).toString()
-      if (fromAddress !== expected.from) continue
-    }
+    const fromAddress = Address.fromScVal(args[0]).toString()
+    if (fromAddress !== expected.from) continue
 
     const toAddress = Address.fromScVal(args[1]).toString()
     if (toAddress !== expected.recipient) continue
@@ -565,7 +563,7 @@ function verifyFromRawOps(
 
 function verifySacTransfer(
   txResult: rpc.Api.GetSuccessfulTransactionResponse,
-  expected: { amount: bigint; currency: string; recipient: string; from?: string },
+  expected: { amount: bigint; currency: string; recipient: string; from: string },
   networkPassphrase: string,
 ) {
   if (!txResult.envelopeXdr) {
@@ -615,7 +613,7 @@ function validateSimulationEvents(
   expectedCurrency: string,
   expectedRecipient: string,
   serverAddress: string | undefined,
-  expectedFrom: string | undefined,
+  expectedFrom: string,
 ) {
   const transferEvents: Array<{ from: string; to: string; amount: bigint; contract: string }> = []
 
@@ -665,7 +663,7 @@ function validateSimulationEvents(
     transfer.to !== expectedRecipient ||
     transfer.amount !== expectedAmount ||
     transfer.contract !== expectedCurrency ||
-    (expectedFrom !== undefined && transfer.from !== expectedFrom)
+    transfer.from !== expectedFrom
   ) {
     throw new PaymentVerificationError(
       `${LOG_PREFIX} Simulation transfer event does not match expected parameters.`,
@@ -673,7 +671,7 @@ function validateSimulationEvents(
         expectedRecipient,
         expectedAmount: expectedAmount.toString(),
         expectedCurrency,
-        ...(expectedFrom !== undefined ? { expectedFrom } : {}),
+        expectedFrom,
       },
     )
   }
@@ -701,18 +699,27 @@ function validateSimulationEvents(
  *
  * Format: `did:pkh:stellar:{network}:{G...publicKey}`
  *
- * Returns `undefined` when the source is absent or in an unexpected format,
- * in which case the `from` check is skipped (graceful degradation for
- * credentials produced without a source field).
+ * Throws `PaymentVerificationError` if the source is absent, not a string,
+ * or does not conform to the expected `did:pkh` format. A credential without
+ * a verifiable source must be rejected — silently skipping the sender check
+ * would leave the hash-theft attack vector open.
  */
-function publicKeyFromDID(source: unknown): string | undefined {
-  if (typeof source !== 'string') return undefined
+function publicKeyFromDID(source: unknown): string {
+  if (typeof source !== 'string' || !source) {
+    throw new PaymentVerificationError(
+      `${LOG_PREFIX} Credential source is required to verify the sender address.`,
+      {},
+    )
+  }
   const parts = source.split(':')
   // did : pkh : stellar : {network} : {pubkey}
   if (parts.length >= 4 && parts[0] === 'did' && parts[1] === 'pkh') {
     return parts[parts.length - 1]
   }
-  return undefined
+  throw new PaymentVerificationError(
+    `${LOG_PREFIX} Credential source has invalid format — expected did:pkh:stellar:{network}:{pubkey}.`,
+    { source },
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/src/shared/scval.test.ts
+++ b/sdk/src/shared/scval.test.ts
@@ -30,11 +30,29 @@ describe('scValToBigInt', () => {
     expect(scValToBigInt(val)).toBe((1n << 64n) | 1n)
   })
 
-  it('converts scvI128', () => {
+  it('converts scvI128 with hi=0', () => {
     const val = xdr.ScVal.scvI128(
       new xdr.Int128Parts({ hi: new xdr.Int64(0), lo: new xdr.Uint64(99) }),
     )
     expect(scValToBigInt(val)).toBe(99n)
+  })
+
+  it('converts scvI128 with non-zero hi (large SAC amounts, regression for NM-006)', () => {
+    // Verifies hi << 64 | lo is computed correctly for large token amounts.
+    // Before the fix, inconsistent implementations could produce wrong results.
+    const val = xdr.ScVal.scvI128(
+      new xdr.Int128Parts({ hi: new xdr.Int64(1), lo: new xdr.Uint64(99) }),
+    )
+    // 1 * 2^64 + 99
+    expect(scValToBigInt(val)).toBe((1n << 64n) + 99n)
+  })
+
+  it('converts scvU128 with non-zero hi (large amounts)', () => {
+    // Verifies u128 with significant hi bits also decodes correctly
+    const val = xdr.ScVal.scvU128(
+      new xdr.UInt128Parts({ hi: new xdr.Uint64(2), lo: new xdr.Uint64(0) }),
+    )
+    expect(scValToBigInt(val)).toBe(2n << 64n)
   })
 
   it('converts scvU128 zero', () => {


### PR DESCRIPTION
## What

- **Channel server `store` required** (breaking) — removed all `if (store)` guards; replay protection, cumulative tracking, and post-close rejection always enforced
- **Channel client cumulative tracking** — optional `store` uses `max(local, server-reported)` baseline to prevent server reset attacks
- **SEP-41 transfer `from` address verified** (breaking) — `credential.source` DID is mandatory; both push and pull modes check `args[0]` matches the credential's claimed sender, blocking hash-theft attacks
- **21 regression tests** — push-mode bypass paths, hash-theft prevention, mandatory source, client cumulative, large i128 values
- **Version bump to 0.4.0**

## Why

Remaining vulnerabilities from audit issues [#201](https://github.com/stellar/internal-agents/issues/201), [#202](https://github.com/stellar/internal-agents/issues/202), [#205](https://github.com/stellar/internal-agents/issues/205):

1. Channel without store = no security (replay, cumulative, close all silently disabled)
2. Channel client trusts server's cumulative claim (server can inflate/reset)
3. No sender verification = hash-theft attack (attacker front-runs client's tx hash, client loses payment)

## Breaking changes

- `channel()` server: `store` is now required
- `charge()` server: `credential.source` (DID) is now mandatory