### PR TITLE
chore: drop minimumReleaseAgeExclude soak exceptions for esbuild and form-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Override the transitive `ws` dependency to `^8.21.0`, clearing a high-severity advisory reachable via `viem` [#49](https://github.com/stellar/stellar-mpp-sdk/pull/49)
 - Override the transitive `form-data` dependency to `^4.0.6`, clearing a high-severity advisory reachable via `@stellar/stellar-sdk` [#49](https://github.com/stellar/stellar-mpp-sdk/pull/49)
+- Drop `minimumReleaseAgeExclude` exemptions for `esbuild` (0.28.1, 2026-06-11) and `form-data` (4.0.6, 2026-06-12) now that both are past the 7-day soak
 
 ## [0.7.0] - 2026-06-15
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,3 @@
 minimumReleaseAge: 10080 # 7 days, in minutes (pnpm uses minutes for this setting)
-minimumReleaseAgeExclude:
-  # Exempt esbuild so its <7-day-old security patch (0.28.1) can resolve; remove once it ages past the soak.
-  - esbuild
-  - '@esbuild/*'
-  # Exempt form-data so its <7-day-old security patch (4.0.6, GHSA-hmw2-7cc7-3qxx) can resolve; remove once it ages past the soak.
-  - form-data
 packages:
   - '.'


### PR DESCRIPTION
## Summary

Both packages exempted from the 7-day `minimumReleaseAgeExclude` soak in `pnpm-workspace.yaml` have now aged past the threshold:

- `esbuild@0.28.1` — published 2026-06-11, now 9 days old
- `form-data@4.0.6` — published 2026-06-12, now 8 days old

With all exceptions removed, the `minimumReleaseAgeExclude` key is dropped entirely from `pnpm-workspace.yaml`. `pnpm audit --audit-level high` remains clean.

## Test plan

- [x] `pnpm install` completes cleanly
- [x] `make check` passes (format, lint, typecheck, 423 tests, build)
- [x] `pnpm audit --audit-level high` reports no known vulnerabilities

---
_Generated by [Claude Code](https://claude.ai/code/session_017oK5S81qvv9shzbZvzQPEv)_