### PR TITLE
Move Soroban RPC calls in channel credential verification out of the cumulative lock 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#55](https://github.com/stellar/stellar-mpp-sdk/pull/55)
+- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#61](https://github.com/stellar/stellar-mpp-sdk/pull/61)
 - Upgrade dependencies to the latest versions clearing the 7-day `minimumReleaseAge` soak, including the `@stellar/stellar-sdk` (`^16.0.1`, major) and `mppx` (`^0.8.1`) peer dependencies — consumers should bump both [#54](https://github.com/stellar/stellar-mpp-sdk/pull/54)
 
 ## [0.7.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#61](https://github.com/stellar/stellar-mpp-sdk/pull/61)
+- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `verifyMaxConcurrent` channel server option (default 10) bounding how many verifications may hold RPC calls at once [#61](https://github.com/stellar/stellar-mpp-sdk/pull/61)
 - Upgrade dependencies to the latest versions clearing the 7-day `minimumReleaseAge` soak, including the `@stellar/stellar-sdk` (`^16.0.1`, major) and `mppx` (`^0.8.1`) peer dependencies — consumers should bump both [#54](https://github.com/stellar/stellar-mpp-sdk/pull/54)
 
 ## [0.7.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#55](https://github.com/stellar/stellar-mpp-sdk/pull/55)
 - Upgrade dependencies to the latest versions clearing the 7-day `minimumReleaseAge` soak, including the `@stellar/stellar-sdk` (`^16.0.1`, major) and `mppx` (`^0.8.1`) peer dependencies — consumers should bump both [#54](https://github.com/stellar/stellar-mpp-sdk/pull/54)
 
 ## [0.7.1]

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ stellar.channel({
   pollDelayMs?: number,           // delay between poll attempts in ms (default: 1,000)
   pollTimeoutMs?: number,         // overall poll timeout in ms (default: 20,000)
   simulationTimeoutMs?: number,   // simulation timeout in ms (default: 10,000)
+  simulateMaxConcurrent?: number, // max verifications simulating at once (default: 10)
   logger?: Logger,                // structured logger (default: no-op)
 })
 ```

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ stellar.channel({
   pollDelayMs?: number,           // delay between poll attempts in ms (default: 1,000)
   pollTimeoutMs?: number,         // overall poll timeout in ms (default: 20,000)
   simulationTimeoutMs?: number,   // simulation timeout in ms (default: 10,000)
-  simulateMaxConcurrent?: number, // max verifications simulating at once (default: 10)
+  verifyMaxConcurrent?: number, // max verifications making RPC calls at once (default: 10)
   logger?: Logger,                // structured logger (default: no-op)
 })
 ```

--- a/examples/charge-server.ts
+++ b/examples/charge-server.ts
@@ -23,7 +23,7 @@ import { Mppx, Store } from 'mppx/server'
 import { Mppx as MppxClient } from 'mppx/client'
 import { stellar } from '../sdk/src/charge/server/index.js'
 import { stellar as stellarClient } from '../sdk/src/charge/client/index.js'
-import { USDC_SAC_TESTNET } from '../sdk/src/constants.js'
+import { USDC_SAC_TESTNET, XLM_SAC_TESTNET } from '../sdk/src/constants.js'
 import { Env } from './config/charge-server.js'
 
 const logger = pino({ level: Env.logLevel })
@@ -50,7 +50,10 @@ const mppx = Mppx.create({
   methods: [
     stellar.charge({
       recipient: Env.stellarRecipient,
-      currency: USDC_SAC_TESTNET,
+      // USDC is a classic issued asset, so payer and recipient both need a USDC
+      // trustline. Set CHARGE_CURRENCY=xlm to run the demo on friendbot funding
+      // alone — native XLM needs no trustline.
+      currency: process.env.CHARGE_CURRENCY === 'xlm' ? XLM_SAC_TESTNET : USDC_SAC_TESTNET,
       network: 'stellar:testnet',
       store: Store.memory(),
       ...(feePayer ? { feePayer } : {}),

--- a/examples/charge-server.ts
+++ b/examples/charge-server.ts
@@ -23,7 +23,7 @@ import { Mppx, Store } from 'mppx/server'
 import { Mppx as MppxClient } from 'mppx/client'
 import { stellar } from '../sdk/src/charge/server/index.js'
 import { stellar as stellarClient } from '../sdk/src/charge/client/index.js'
-import { USDC_SAC_TESTNET, XLM_SAC_TESTNET } from '../sdk/src/constants.js'
+import { USDC_SAC_TESTNET } from '../sdk/src/constants.js'
 import { Env } from './config/charge-server.js'
 
 const logger = pino({ level: Env.logLevel })
@@ -50,10 +50,7 @@ const mppx = Mppx.create({
   methods: [
     stellar.charge({
       recipient: Env.stellarRecipient,
-      // USDC is a classic issued asset, so payer and recipient both need a USDC
-      // trustline. Set CHARGE_CURRENCY=xlm to run the demo on friendbot funding
-      // alone — native XLM needs no trustline.
-      currency: process.env.CHARGE_CURRENCY === 'xlm' ? XLM_SAC_TESTNET : USDC_SAC_TESTNET,
+      currency: USDC_SAC_TESTNET,
       network: 'stellar:testnet',
       store: Store.memory(),
       ...(feePayer ? { feePayer } : {}),

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -2978,3 +2978,113 @@ describe('channel server close transaction inspection (auth-tree injection)', ()
     expect(mockSendTransaction).not.toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// RPC-outside-the-lock tests
+// ---------------------------------------------------------------------------
+
+describe('channel verification runs RPC outside the cumulative lock', () => {
+  const COMMITMENT_BYTES = Buffer.from('unlocked-rpc-commitment-bytes')
+
+  /**
+   * Replaces the simulate mock with a slow one that records how many
+   * simulations are in flight at once.
+   *
+   * @returns A live counter — read `max` after the verifies settle.
+   */
+  function trackSimulateConcurrency(delayMs = 50) {
+    const counter = { inFlight: 0, max: 0 }
+    mockSimulateTransaction.mockReset()
+    mockSimulateTransaction.mockImplementation(() => {
+      counter.inFlight++
+      counter.max = Math.max(counter.max, counter.inFlight)
+      return new Promise((resolve) =>
+        setTimeout(() => {
+          counter.inFlight--
+          resolve(successSimResult(COMMITMENT_BYTES))
+        }, delayMs),
+      )
+    })
+    return counter
+  }
+
+  /** Credentials all signed over the same bytes, so each passes the mocked
+   *  `prepare_commitment` signature check regardless of its amount. */
+  function makeConcurrentCredentials(amounts: bigint[]) {
+    return amounts.map((amount) =>
+      makeSignedCredential({
+        commitmentBytes: COMMITMENT_BYTES,
+        cumulativeAmount: amount,
+        challengeAmount: amount.toString(),
+      }),
+    )
+  }
+
+  it('overlaps simulations across concurrent verifies instead of serializing them', async () => {
+    // The regression this guards: when the signature simulation ran under the
+    // cumulative lock, only one could ever be in flight, so a slow RPC stalled
+    // every concurrent payer on the channel.
+    const counter = trackSimulateConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: false,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(counter.max).toBe(4)
+  })
+
+  it('bounds concurrent simulations by simulateMaxConcurrent', async () => {
+    // With the lock no longer serializing RPC, the semaphore is the only cap on
+    // fan-out onto the RPC provider.
+    const counter = trackSimulateConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: false,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+      simulateMaxConcurrent: 2,
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(counter.max).toBe(2)
+  })
+
+  it('still admits exactly one of several concurrent credentials at the same cumulative', async () => {
+    // Unlocked RPC must not weaken monotonicity: all four clear the pre-RPC
+    // short-circuit against a cumulative of 0, then serialize in the locked
+    // commit, where only the first can advance the cumulative.
+    trackSimulateConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: false,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 1000n, 1000n, 1000n])
+    const results = await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1)
+    for (const rejected of results.filter((r) => r.status === 'rejected')) {
+      expect((rejected as PromiseRejectedResult).reason.message).toContain(
+        'must be greater than previous cumulative',
+      )
+    }
+  })
+})

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -3101,7 +3101,7 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
     expect(stateReads.max).toBe(4)
   })
 
-  it('bounds concurrent on-chain state reads by simulateMaxConcurrent', async () => {
+  it('bounds concurrent on-chain state reads by verifyMaxConcurrent', async () => {
     // The semaphore wraps both RPC paths, so it caps state reads too.
     trackSimulateConcurrency(0)
     const stateReads = trackStateReadConcurrency()
@@ -3111,7 +3111,7 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
       checkOnChainState: true,
       commitmentKey: COMMITMENT_KEY,
       store: Store.memory(),
-      simulateMaxConcurrent: 2,
+      verifyMaxConcurrent: 2,
     })
 
     const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
@@ -3122,7 +3122,7 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
     expect(stateReads.max).toBe(2)
   })
 
-  it('bounds concurrent simulations by simulateMaxConcurrent', async () => {
+  it('bounds concurrent simulations by verifyMaxConcurrent', async () => {
     // With the lock no longer serializing RPC, the semaphore is the only cap on
     // fan-out onto the RPC provider.
     const counter = trackSimulateConcurrency()
@@ -3132,7 +3132,7 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
       checkOnChainState: false,
       commitmentKey: COMMITMENT_KEY,
       store: Store.memory(),
-      simulateMaxConcurrent: 2,
+      verifyMaxConcurrent: 2,
     })
 
     const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -1,6 +1,6 @@
 import { Account, Address, Keypair, Networks, Transaction, xdr } from '@stellar/stellar-sdk'
 import { Challenge, Credential, Store } from 'mppx'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Hoisted mock stubs — accessible inside the vi.mock factory
 const mockGetAccount = vi.fn()
@@ -2986,6 +2986,14 @@ describe('channel server close transaction inspection (auth-tree injection)', ()
 describe('channel verification runs RPC outside the cumulative lock', () => {
   const COMMITMENT_BYTES = Buffer.from('unlocked-rpc-commitment-bytes')
 
+  // These tests swap in delayed mock implementations. Mocks are not auto-cleared
+  // in this file, so restore the module-level defaults rather than leaving a
+  // slow getChannelState behind for whatever test is added next.
+  afterEach(() => {
+    mockGetChannelState.mockReset()
+    mockGetChannelState.mockResolvedValue(mockHealthyChannelState())
+  })
+
   /**
    * Replaces the simulate mock with a slow one that records how many
    * simulations are in flight at once.
@@ -3002,6 +3010,33 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
         setTimeout(() => {
           counter.inFlight--
           resolve(successSimResult(COMMITMENT_BYTES))
+        }, delayMs),
+      )
+    })
+    return counter
+  }
+
+  /**
+   * Replaces the on-chain state mock with a slow one that records how many
+   * state reads are in flight at once.
+   *
+   * `verifyOnChainState` is a separate, multi-call RPC path from the
+   * signature simulation, so it needs its own overlap assertion — tests that
+   * run with `checkOnChainState: false` would still pass if this path alone
+   * were moved back under the cumulative lock.
+   *
+   * @returns A live counter — read `max` after the verifies settle.
+   */
+  function trackStateReadConcurrency(delayMs = 50) {
+    const counter = { inFlight: 0, max: 0 }
+    mockGetChannelState.mockReset()
+    mockGetChannelState.mockImplementation(() => {
+      counter.inFlight++
+      counter.max = Math.max(counter.max, counter.inFlight)
+      return new Promise((resolve) =>
+        setTimeout(() => {
+          counter.inFlight--
+          resolve(mockHealthyChannelState())
         }, delayMs),
       )
     })
@@ -3039,6 +3074,52 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
     )
 
     expect(counter.max).toBe(4)
+  })
+
+  it('overlaps on-chain state reads across concurrent verifies', async () => {
+    // Same guarantee as above, for the other RPC path. `verifyOnChainState`
+    // costs several calls, so serializing it under the lock would stall
+    // concurrent payers just as badly — and the checkOnChainState: false tests
+    // above cannot detect that.
+    trackSimulateConcurrency(0)
+    const stateReads = trackStateReadConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: true,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    // All four reach the state read together: one verification progresses into
+    // it while the others' reads are still pending.
+    expect(stateReads.max).toBe(4)
+  })
+
+  it('bounds concurrent on-chain state reads by simulateMaxConcurrent', async () => {
+    // The semaphore wraps both RPC paths, so it caps state reads too.
+    trackSimulateConcurrency(0)
+    const stateReads = trackStateReadConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: true,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+      simulateMaxConcurrent: 2,
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(stateReads.max).toBe(2)
   })
 
   it('bounds concurrent simulations by simulateMaxConcurrent', async () => {

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -25,7 +25,7 @@ import {
   DEFAULT_POLL_MAX_ATTEMPTS,
   DEFAULT_POLL_MAX_CONCURRENT,
   DEFAULT_POLL_TIMEOUT_MS,
-  DEFAULT_SIMULATE_MAX_CONCURRENT,
+  DEFAULT_VERIFY_MAX_CONCURRENT,
   DEFAULT_SIMULATION_TIMEOUT_MS,
 } from '../../shared/defaults.js'
 import { Semaphore } from '../../shared/semaphore.js'
@@ -147,7 +147,7 @@ export function channel(parameters: channel.Parameters) {
     pollMaxConcurrent = DEFAULT_POLL_MAX_CONCURRENT,
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
     rpcUrl,
-    simulateMaxConcurrent = DEFAULT_SIMULATE_MAX_CONCURRENT,
+    verifyMaxConcurrent = DEFAULT_VERIFY_MAX_CONCURRENT,
     simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
     store,
     feeBudget,
@@ -158,9 +158,9 @@ export function channel(parameters: channel.Parameters) {
   const networkPassphrase = NETWORK_PASSPHRASE[network]
   const rpcServer = new rpc.Server(resolvedRpcUrl)
   const pollSemaphore = new Semaphore(pollMaxConcurrent)
-  // Bounds credential verifications holding RPC simulations concurrently. The
-  // simulations run outside cumulativeLock, so this is the only cap on fan-out.
-  const simulateSemaphore = new Semaphore(simulateMaxConcurrent)
+  // Bounds credential verifications holding RPC calls concurrently. Those calls
+  // run outside cumulativeLock, so this is the only cap on fan-out.
+  const verifySemaphore = new Semaphore(verifyMaxConcurrent)
 
   // Parse the commitment public key (accepts G... Stellar public key string or Keypair)
   const commitmentKP = (() => {
@@ -418,7 +418,7 @@ export function channel(parameters: channel.Parameters) {
     // in flight as a side effect of serialising validation; now that the RPC
     // runs unlocked, that cap has to be explicit or a burst of credentials fans
     // straight out onto the RPC provider.
-    await simulateSemaphore.acquire()
+    await verifySemaphore.acquire()
     try {
       // Verify the commitment signature before anything writes channel state.
       await verifyCommitmentSignature(commitmentAmount, signatureBytes)
@@ -431,7 +431,7 @@ export function channel(parameters: channel.Parameters) {
         await verifyOnChainState(commitmentAmount)
       }
     } finally {
-      simulateSemaphore.release()
+      verifySemaphore.release()
     }
 
     // A close can only be settled by a server configured with an envelope signer.
@@ -1172,15 +1172,15 @@ export declare namespace channel {
      */
     rpcUrl?: string
     /**
-     * Maximum credential verifications allowed to hold Soroban RPC simulations
-     * at once. Verification runs its simulations outside the cumulative lock so
-     * a slow RPC cannot stall concurrent payers, which makes this the only
-     * bound on RPC fan-out under a burst of credentials. Callers past the limit
-     * queue briefly and are then rejected with a `SemaphoreTimeoutError`.
+     * Maximum credential verifications allowed to hold Soroban RPC calls at
+     * once. Verification makes those calls outside the cumulative lock so a slow
+     * RPC cannot stall concurrent payers, which makes this the only bound on RPC
+     * fan-out under a burst of credentials. Callers past the limit queue briefly
+     * and are then rejected with a `SemaphoreTimeoutError`.
      *
      * @default 10
      */
-    simulateMaxConcurrent?: number
+    verifyMaxConcurrent?: number
     /** Simulation timeout in milliseconds. @default 10_000 */
     simulationTimeoutMs?: number
     /**

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -693,27 +693,13 @@ export function channel(parameters: channel.Parameters) {
       return { windowStartMs, spentStroops: spentStroops + charge }
     }
 
-    // Prefer the store's atomic read-modify-write so the budget holds under
-    // concurrent settlements (which run outside the cumulative lock). Stores
-    // without `update` fall back to get/put — best-effort under cross-process
-    // races, acceptable for a fee-drain guard rather than a hard cap.
-    const atomicStore = store as {
-      update?: (
-        key: string,
-        fn: (current: FeeBudgetRecord | null) => Store.Change<FeeBudgetRecord, void>,
-      ) => Promise<void>
-    }
-
-    if (typeof atomicStore.update === 'function') {
-      await atomicStore.update(budgetKey, (current) => ({
-        op: 'set',
-        value: applyCharge(current),
-        result: undefined,
-      }))
-    } else {
-      const current = (await store.get(budgetKey)) as FeeBudgetRecord | null
-      await store.put(budgetKey, applyCharge(current))
-    }
+    // Atomic read-modify-write so the budget holds under concurrent settlements
+    // (which run outside the cumulative lock).
+    await store.update(budgetKey, (current): Store.Change<FeeBudgetRecord, void> => ({
+      op: 'set',
+      value: applyCharge(current as FeeBudgetRecord | null),
+      result: undefined,
+    }))
   }
 
   /**

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_POLL_MAX_ATTEMPTS,
   DEFAULT_POLL_MAX_CONCURRENT,
   DEFAULT_POLL_TIMEOUT_MS,
+  DEFAULT_SIMULATE_MAX_CONCURRENT,
   DEFAULT_SIMULATION_TIMEOUT_MS,
 } from '../../shared/defaults.js'
 import { Semaphore } from '../../shared/semaphore.js'
@@ -146,6 +147,7 @@ export function channel(parameters: channel.Parameters) {
     pollMaxConcurrent = DEFAULT_POLL_MAX_CONCURRENT,
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
     rpcUrl,
+    simulateMaxConcurrent = DEFAULT_SIMULATE_MAX_CONCURRENT,
     simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
     store,
     feeBudget,
@@ -156,6 +158,9 @@ export function channel(parameters: channel.Parameters) {
   const networkPassphrase = NETWORK_PASSPHRASE[network]
   const rpcServer = new rpc.Server(resolvedRpcUrl)
   const pollSemaphore = new Semaphore(pollMaxConcurrent)
+  // Bounds credential verifications holding RPC simulations concurrently. The
+  // simulations run outside cumulativeLock, so this is the only cap on fan-out.
+  const simulateSemaphore = new Semaphore(simulateMaxConcurrent)
 
   // Parse the commitment public key (accepts G... Stellar public key string or Keypair)
   const commitmentKP = (() => {
@@ -235,17 +240,26 @@ export function channel(parameters: channel.Parameters) {
       }
     },
     async verify({ credential }) {
-      // Phase 1: validate and update cumulative under lock (fast path).
-      // Phase 2: long operations (broadcast, poll) run outside the lock.
-      const validated = await new Promise<ValidatedCredential>((resolve, reject) => {
-        cumulativeLock = cumulativeLock.then(
-          () => doValidate(credential).then(resolve, reject),
-          () => doValidate(credential).then(resolve, reject),
-        )
-      })
+      // Phase 1a: format checks, replay claim, and RPC — outside the lock.
+      // Phase 1b: authoritative cumulative write — under the lock, store only.
+      // Phase 2: broadcast and poll for a close — outside the lock.
+      const prepared = await doPrepare(credential)
+      const validated = await withCumulativeLock(() => doCommit(prepared))
       return doSettle(validated)
     },
   })
+
+  /** Output of {@link doPrepare}: everything {@link doCommit} needs to write
+   *  channel state without re-reading the credential. */
+  type PreparedCredential = {
+    action: 'voucher' | 'close'
+    commitmentAmount: bigint
+    requestedAmount: bigint
+    signatureBytes: Buffer
+    challengeStoreKey: string
+    challengeReference: string
+    externalId?: string
+  }
 
   type ValidatedCredential =
     | { action: 'voucher'; receipt: Receipt.Receipt }
@@ -258,21 +272,29 @@ export function channel(parameters: channel.Parameters) {
       }
 
   /**
-   * Phase 1 — validation (runs under {@link cumulativeLock}).
+   * Serializes `fn` against every other holder of the cumulative lock.
    *
-   * Performs replay protection, cumulative amount checks, and signature
-   * verification. For vouchers, writes the cumulative and returns the
-   * receipt directly. For close, returns the validated state so
-   * the long on-chain operation can run outside the lock.
+   * The same callback is passed to both `.then` arms so a rejected predecessor
+   * does not poison the chain — without the second arm, one failed validation
+   * would leave `cumulativeLock` permanently rejected and every later caller
+   * would skip its turn.
    */
-  async function doValidate(credential: ChannelCredential): Promise<ValidatedCredential> {
-    const { challenge, payload } = credential
-    const { request: challengeRequest } = challenge
+  function withCumulativeLock<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      cumulativeLock = cumulativeLock.then(
+        () => fn().then(resolve, reject),
+        () => fn().then(resolve, reject),
+      )
+    })
+  }
 
-    const action = payload.action ?? 'voucher'
-    const { externalId } = challengeRequest
-
-    // Reject credentials once the channel has been closed on-chain. Applied to all actions.
+  /**
+   * Rejects credentials once the channel has been closed on-chain.
+   *
+   * Read by both phases: {@link doPrepare} rejects early to avoid spending RPC,
+   * and {@link doCommit} re-reads because an RPC round-trip has elapsed since.
+   */
+  async function assertNotClosed(): Promise<void> {
     const closed = await store.get(`${STORE_PREFIX}:closed:${channelAddress}`)
     if (closed) {
       logger.warn(`${LOG_PREFIX} Rejecting credential — channel already closed`, {
@@ -283,6 +305,31 @@ export function channel(parameters: channel.Parameters) {
         { channel: channelAddress },
       )
     }
+  }
+
+  /**
+   * Phase 1a — checks and RPC (runs OUTSIDE {@link cumulativeLock}).
+   *
+   * Claims the challenge, validates formats, and proves the commitment
+   * signature authentic. Nothing here writes channel state beyond the
+   * self-synchronising challenge claim, so the lifecycle reads are advisory:
+   * they shed obvious rejects before any RPC is spent, and the authoritative
+   * checks run in {@link doCommit} under the lock.
+   *
+   * Keeping RPC out of the lock is deliberate. A simulation is bounded by
+   * `simulationTimeoutMs` (default 10s) and the on-chain state query costs
+   * several more calls; holding the lock across them lets a single credential
+   * stall every concurrent payer on this channel.
+   */
+  async function doPrepare(credential: ChannelCredential): Promise<PreparedCredential> {
+    const { challenge, payload } = credential
+    const { request: challengeRequest } = challenge
+
+    const action = payload.action ?? 'voucher'
+    const { externalId } = challengeRequest
+
+    // Advisory lifecycle reads — re-checked authoritatively in doCommit.
+    await assertNotClosed()
 
     // Reject all actions if a close is currently settling. The settling marker is set
     // atomically under the lock when a close is accepted, and remains set until settlement
@@ -315,7 +362,8 @@ export function channel(parameters: channel.Parameters) {
     }
 
     // Replay protection via atomic compare-and-set: reject if challenge already used.
-    // Applied to all actions.
+    // Applied to all actions. Self-synchronising, so it needs no lock — and it runs
+    // ahead of the RPC below so replayed challenges are shed without a round-trip.
     const challengeStoreKey = `${STORE_PREFIX}:challenge:${challenge.id}`
     const replayError = new ChannelVerificationError('Challenge already used. Replay rejected.', {
       channel: channelAddress,
@@ -354,8 +402,9 @@ export function channel(parameters: channel.Parameters) {
     // Cheap monotonicity short-circuit before any RPC work: a commitment that
     // cannot advance the cumulative is rejected here, so a flood of stale or
     // non-monotonic commitments cannot amplify into signature-verify and
-    // on-chain-state RPC load. The atomic store.update below stays authoritative,
-    // re-reading the latest cumulative to remain correct under concurrent writes.
+    // on-chain-state RPC load. The atomic store.update in doCommit stays
+    // authoritative, re-reading the latest cumulative to remain correct under
+    // concurrent writes.
     const preCheckError = cumulativeMonotonicityError(
       readCumulativeAmount(cumulativeRecord),
       commitmentAmount,
@@ -365,16 +414,24 @@ export function channel(parameters: channel.Parameters) {
       throw preCheckError
     }
 
-    // Verify commitment signature before atomic cumulative update
-    // (async work must complete before the atomic CAS)
-    await verifyCommitmentSignature(commitmentAmount, signatureBytes)
+    // Bound concurrent RPC. The cumulative lock used to cap simulations at one
+    // in flight as a side effect of serialising validation; now that the RPC
+    // runs unlocked, that cap has to be explicit or a burst of credentials fans
+    // straight out onto the RPC provider.
+    await simulateSemaphore.acquire()
+    try {
+      // Verify the commitment signature before anything writes channel state.
+      await verifyCommitmentSignature(commitmentAmount, signatureBytes)
 
-    // Query on-chain state only after the commitment signature is proven
-    // authentic. The state read costs several RPC calls; gating it behind the
-    // cheaper signature check stops a forged voucher from amplifying into the
-    // full state query.
-    if (checkOnChainState) {
-      await verifyOnChainState(commitmentAmount)
+      // Query on-chain state only after the commitment signature is proven
+      // authentic. The state read costs several RPC calls; gating it behind the
+      // cheaper signature check stops a forged voucher from amplifying into the
+      // full state query.
+      if (checkOnChainState) {
+        await verifyOnChainState(commitmentAmount)
+      }
+    } finally {
+      simulateSemaphore.release()
     }
 
     // A close can only be settled by a server configured with an envelope signer.
@@ -386,6 +443,41 @@ export function channel(parameters: channel.Parameters) {
         {},
       )
     }
+
+    return {
+      action,
+      commitmentAmount,
+      requestedAmount,
+      signatureBytes,
+      challengeStoreKey,
+      challengeReference: challengeRequest.methodDetails?.reference ?? challenge.id,
+      ...(externalId ? { externalId } : {}),
+    }
+  }
+
+  /**
+   * Phase 1b — authoritative state write (runs UNDER {@link cumulativeLock}).
+   *
+   * Holds the lock for store operations only: one atomic cumulative update plus
+   * a marker write. For vouchers this returns the receipt directly; for a close
+   * it returns the validated state so settlement can run outside the lock.
+   */
+  async function doCommit(prepared: PreparedCredential): Promise<ValidatedCredential> {
+    const {
+      action,
+      commitmentAmount,
+      requestedAmount,
+      signatureBytes,
+      challengeStoreKey,
+      challengeReference,
+      externalId,
+    } = prepared
+
+    // Re-read: an RPC round-trip elapsed inside doPrepare, so its lifecycle
+    // reads may be seconds stale. The cumulative update below covers `settling`
+    // (that flag lives in the cumulative record); `closed` is a separate key and
+    // has to be re-read here.
+    await assertNotClosed()
 
     // Atomic cumulative monotonic check and write: reject if invariants fail,
     // or write the new cumulative if all checks pass.
@@ -413,7 +505,7 @@ export function channel(parameters: channel.Parameters) {
         }
 
         // Authoritative monotonicity check against the latest stored cumulative,
-        // applying the same rules as the pre-RPC short-circuit above.
+        // applying the same rules as the pre-RPC short-circuit in doPrepare.
         const monotonicityError = cumulativeMonotonicityError(
           previousCumulative,
           commitmentAmount,
@@ -463,7 +555,7 @@ export function channel(parameters: channel.Parameters) {
       action: 'voucher',
       receipt: Receipt.from({
         method: 'stellar',
-        reference: challengeRequest.methodDetails?.reference ?? challenge.id,
+        reference: challengeReference,
         status: 'success',
         timestamp: new Date().toISOString(),
         ...(externalId ? { externalId } : {}),
@@ -1079,6 +1171,16 @@ export declare namespace channel {
      * ```
      */
     rpcUrl?: string
+    /**
+     * Maximum credential verifications allowed to hold Soroban RPC simulations
+     * at once. Verification runs its simulations outside the cumulative lock so
+     * a slow RPC cannot stall concurrent payers, which makes this the only
+     * bound on RPC fan-out under a burst of credentials. Callers past the limit
+     * queue briefly and are then rejected with a `SemaphoreTimeoutError`.
+     *
+     * @default 10
+     */
+    simulateMaxConcurrent?: number
     /** Simulation timeout in milliseconds. @default 10_000 */
     simulationTimeoutMs?: number
     /**

--- a/sdk/src/shared/defaults.ts
+++ b/sdk/src/shared/defaults.ts
@@ -9,11 +9,11 @@ export const DEFAULT_POLL_TIMEOUT_MS = 20_000
 export const DEFAULT_POLL_MAX_CONCURRENT = 10
 export const DEFAULT_SIMULATION_TIMEOUT_MS = 10_000
 /**
- * Maximum credential verifications allowed to hold Soroban RPC simulations at
- * once. Channel verification runs its simulations outside the cumulative lock,
- * so this is the only bound on RPC fan-out under a burst of credentials.
+ * Maximum credential verifications allowed to hold Soroban RPC calls at once.
+ * Channel verification makes those calls outside the cumulative lock, so this
+ * is the only bound on RPC fan-out under a burst of credentials.
  */
-export const DEFAULT_SIMULATE_MAX_CONCURRENT = 10
+export const DEFAULT_VERIFY_MAX_CONCURRENT = 10
 
 /**
  * Default timeout in seconds for read-only contract getter simulations (State.ts).

--- a/sdk/src/shared/defaults.ts
+++ b/sdk/src/shared/defaults.ts
@@ -8,6 +8,12 @@ export const DEFAULT_POLL_JITTER_MS = 200
 export const DEFAULT_POLL_TIMEOUT_MS = 20_000
 export const DEFAULT_POLL_MAX_CONCURRENT = 10
 export const DEFAULT_SIMULATION_TIMEOUT_MS = 10_000
+/**
+ * Maximum credential verifications allowed to hold Soroban RPC simulations at
+ * once. Channel verification runs its simulations outside the cumulative lock,
+ * so this is the only bound on RPC fan-out under a burst of credentials.
+ */
+export const DEFAULT_SIMULATE_MAX_CONCURRENT = 10
 
 /**
  * Default timeout in seconds for read-only contract getter simulations (State.ts).


### PR DESCRIPTION
https://hackerone.com/reports/3904771

There's another PR based off of this to remove RPC call https://github.com/stellar/stellar-mpp-sdk/pull/63