### PR TITLE
fix: build channel commitments locally instead of fetching them over RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#55](https://github.com/stellar/stellar-mpp-sdk/pull/55)
+- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#61](https://github.com/stellar/stellar-mpp-sdk/pull/61)
 - Upgrade dependencies to the latest versions clearing the 7-day `minimumReleaseAge` soak, including the `@stellar/stellar-sdk` (`^16.0.1`, major) and `mppx` (`^0.8.1`) peer dependencies — consumers should bump both [#54](https://github.com/stellar/stellar-mpp-sdk/pull/54)
 
 ## [0.7.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#55](https://github.com/stellar/stellar-mpp-sdk/pull/55)
 - Upgrade dependencies to the latest versions clearing the 7-day `minimumReleaseAge` soak, including the `@stellar/stellar-sdk` (`^16.0.1`, major) and `mppx` (`^0.8.1`) peer dependencies — consumers should bump both [#54](https://github.com/stellar/stellar-mpp-sdk/pull/54)
 
 ## [0.7.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Build the channel commitment message locally instead of fetching it from an unauthenticated `prepare_commitment` simulation. The server previously verified a client's signature against bytes returned by RPC while crediting the amount from the credential payload, so a compromised or intercepted RPC endpoint could have returned a commitment for a smaller amount than the one being credited. The bytes are now derived from the amount, channel and network the server already holds, so they cannot disagree with what is credited [#63](https://github.com/stellar/stellar-mpp-sdk/pull/63)
+
 ### Changed
 
+- Remove the per-voucher `prepare_commitment` RPC round trip from both channel client and server. The commitment message is fully determined by the amount, channel, network and a constant domain separator, so it is now built locally: signing and verification are CPU-only, and a payer no longer needs RPC reachability to sign a voucher. A live parity test (`integration/live`) asserts the local encoding matches the deployed contract byte-for-byte, replacing the contract round trip as the drift guard. `simulateMaxConcurrent` now bounds only the on-chain state read; the client's `rpcUrl` and `simulationTimeoutMs` options are deprecated and ignored [#63](https://github.com/stellar/stellar-mpp-sdk/pull/63)
 - Move Soroban RPC calls in channel credential verification (commitment-signature simulation and the on-chain state query) out of the cumulative lock, so a slow RPC no longer stalls every concurrent payer on a channel. The authoritative cumulative check and write still run under the lock. Adds a `simulateMaxConcurrent` channel server option (default 10) bounding how many verifications may hold simulations at once [#61](https://github.com/stellar/stellar-mpp-sdk/pull/61)
 - Upgrade dependencies to the latest versions clearing the 7-day `minimumReleaseAge` soak, including the `@stellar/stellar-sdk` (`^16.0.1`, major) and `mppx` (`^0.8.1`) peer dependencies — consumers should bump both [#54](https://github.com/stellar/stellar-mpp-sdk/pull/54)
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ stellar.channel({
   pollDelayMs?: number,           // delay between poll attempts in ms (default: 1,000)
   pollTimeoutMs?: number,         // overall poll timeout in ms (default: 20,000)
   simulationTimeoutMs?: number,   // simulation timeout in ms (default: 10,000)
+  simulateMaxConcurrent?: number, // max verifications simulating at once (default: 10)
   logger?: Logger,                // structured logger (default: no-op)
 })
 ```

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ stellar.channel({
   pollDelayMs?: number,           // delay between poll attempts in ms (default: 1,000)
   pollTimeoutMs?: number,         // overall poll timeout in ms (default: 20,000)
   simulationTimeoutMs?: number,   // simulation timeout in ms (default: 10,000)
-  simulateMaxConcurrent?: number, // max verifications simulating at once (default: 10)
+  simulateMaxConcurrent?: number, // max concurrent on-chain state reads (default: 10)
   logger?: Logger,                // structured logger (default: no-op)
 })
 ```

--- a/examples/charge-server.ts
+++ b/examples/charge-server.ts
@@ -23,7 +23,7 @@ import { Mppx, Store } from 'mppx/server'
 import { Mppx as MppxClient } from 'mppx/client'
 import { stellar } from '../sdk/src/charge/server/index.js'
 import { stellar as stellarClient } from '../sdk/src/charge/client/index.js'
-import { USDC_SAC_TESTNET } from '../sdk/src/constants.js'
+import { USDC_SAC_TESTNET, XLM_SAC_TESTNET } from '../sdk/src/constants.js'
 import { Env } from './config/charge-server.js'
 
 const logger = pino({ level: Env.logLevel })
@@ -50,7 +50,10 @@ const mppx = Mppx.create({
   methods: [
     stellar.charge({
       recipient: Env.stellarRecipient,
-      currency: USDC_SAC_TESTNET,
+      // USDC is a classic issued asset, so payer and recipient both need a USDC
+      // trustline. Set CHARGE_CURRENCY=xlm to run the demo on friendbot funding
+      // alone — native XLM needs no trustline.
+      currency: process.env.CHARGE_CURRENCY === 'xlm' ? XLM_SAC_TESTNET : USDC_SAC_TESTNET,
       network: 'stellar:testnet',
       store: Store.memory(),
       ...(feePayer ? { feePayer } : {}),

--- a/examples/charge-server.ts
+++ b/examples/charge-server.ts
@@ -23,7 +23,7 @@ import { Mppx, Store } from 'mppx/server'
 import { Mppx as MppxClient } from 'mppx/client'
 import { stellar } from '../sdk/src/charge/server/index.js'
 import { stellar as stellarClient } from '../sdk/src/charge/client/index.js'
-import { USDC_SAC_TESTNET, XLM_SAC_TESTNET } from '../sdk/src/constants.js'
+import { USDC_SAC_TESTNET } from '../sdk/src/constants.js'
 import { Env } from './config/charge-server.js'
 
 const logger = pino({ level: Env.logLevel })
@@ -50,10 +50,7 @@ const mppx = Mppx.create({
   methods: [
     stellar.charge({
       recipient: Env.stellarRecipient,
-      // USDC is a classic issued asset, so payer and recipient both need a USDC
-      // trustline. Set CHARGE_CURRENCY=xlm to run the demo on friendbot funding
-      // alone — native XLM needs no trustline.
-      currency: process.env.CHARGE_CURRENCY === 'xlm' ? XLM_SAC_TESTNET : USDC_SAC_TESTNET,
+      currency: USDC_SAC_TESTNET,
       network: 'stellar:testnet',
       store: Store.memory(),
       ...(feePayer ? { feePayer } : {}),

--- a/package.json
+++ b/package.json
@@ -87,12 +87,15 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
     "viem": "^2.53.1",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.10"
   },
   "pnpm": {
     "overrides": {
       "axios": "^1.18.1",
+      "brace-expansion": "^5.0.9",
       "form-data": "^4.0.6",
+      "ip-address": "^10.3.1",
+      "postcss": "^8.5.23",
       "vite": "^8.1.0",
       "ws": "^8.21.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,10 @@ settings:
 
 overrides:
   axios: ^1.18.1
+  brace-expansion: ^5.0.9
   form-data: ^4.0.6
+  ip-address: ^10.3.1
+  postcss: ^8.5.23
   vite: ^8.1.0
   ws: ^8.21.0
 
@@ -32,7 +35,7 @@ importers:
         version: 26.0.1
       '@vitest/coverage-v8':
         specifier: ^4.1.9
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(vitest@4.1.10)
       eslint:
         specifier: ^10.6.0
         version: 10.6.0
@@ -70,8 +73,8 @@ importers:
         specifier: ^2.53.1
         version: 2.53.1(typescript@6.0.3)(zod@4.4.3)
       vitest:
-        specifier: ^4.1.9
-        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -617,11 +620,11 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.9':
-    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@4.1.9':
-    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^8.1.0
@@ -631,17 +634,23 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
   '@vitest/pretty-format@4.1.9':
     resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
-  '@vitest/runner@4.1.9':
-    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.9':
-    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.9':
-    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
@@ -724,9 +733,9 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -1073,8 +1082,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1277,8 +1286,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1366,8 +1375,8 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1633,20 +1642,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.9:
-    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-preview': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
-      '@vitest/coverage-istanbul': 4.1.9
-      '@vitest/coverage-v8': 4.1.9
-      '@vitest/ui': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^8.1.0
@@ -2158,7 +2167,7 @@ snapshots:
       '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.9
@@ -2170,42 +2179,52 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
-  '@vitest/expect@4.1.9':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.9
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.9':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.9':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.9': {}
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -2291,7 +2310,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2495,7 +2514,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -2671,7 +2690,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -2808,7 +2827,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   mppx@0.8.1(express@5.2.1)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
@@ -2825,7 +2844,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -2918,9 +2937,9 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
 
-  postcss@8.5.16:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3167,7 +3186,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.25
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -3177,15 +3196,15 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       es-module-lexer: 2.2.0
       expect-type: 1.4.0
       magic-string: 0.30.21
@@ -3201,7 +3220,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.0.1
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/sdk/src/channel/client/Channel.test.ts
+++ b/sdk/src/channel/client/Channel.test.ts
@@ -1,7 +1,9 @@
 import { Address, Keypair, Networks, hash, nativeToScVal, xdr } from '@stellar/stellar-sdk'
 import { Challenge, Store } from 'mppx'
 import { describe, expect, it, vi } from 'vitest'
+import { STELLAR_PUBNET, STELLAR_TESTNET } from '../../constants.js'
 import { StellarMppError } from '../../shared/errors.js'
+import { buildCommitmentMessage } from '../commitment.js'
 
 const mockGetAccount = vi.fn()
 const mockSimulateTransaction = vi.fn()
@@ -536,8 +538,6 @@ describe('channel pinning (allowedChannels)', () => {
 
   it('accepts channel address in allowedChannels list', async () => {
     mockSimulateTransaction.mockClear()
-    const commitmentBytes = buildCommitment({ amount: 1_000_000n })
-    mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const method = channel({
       commitmentKey: TEST_KEYPAIR,
@@ -554,8 +554,8 @@ describe('channel pinning (allowedChannels)', () => {
     const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
     expect(decoded.payload.signature).toMatch(/^[0-9a-f]{128}$/)
 
-    // Verify simulate was called
-    expect(mockSimulateTransaction).toHaveBeenCalled()
+    // Signing is fully local now — a pinned channel is accepted without RPC.
+    expect(mockSimulateTransaction).not.toHaveBeenCalled()
   })
 
   it('accepts channel address when explicitly opting out of pinning', async () => {
@@ -605,114 +605,74 @@ describe('channel pinning (allowedChannels)', () => {
 })
 
 describe('commitment byte-binding', () => {
-  it('refuses to sign when the simulated commitment encodes a different amount than intended', async () => {
-    // The client intends to sign cumulative 1000000, but the simulation
-    // returns a commitment for a different amount; it must refuse to sign.
-    mockSimulateTransaction.mockResolvedValueOnce(
-      successSimResult(buildCommitment({ amount: 999_999_999n })),
-    )
+  // The client used to fetch the commitment over RPC and check that the
+  // returned bytes bound to the intended channel/amount/network before signing.
+  // It now builds those bytes itself, so a mismatch is not something to detect
+  // — it is unrepresentable. These tests assert the resulting binding directly:
+  // the signature must verify against the intended message and nothing else.
 
-    const method = makeMethod()
-    const challenge = mockChallenge() // requests amount 1000000
-
-    await expect(
-      method.createCredential({ challenge: challenge as any, context: {} as any }),
-    ).rejects.toThrow(/amount mismatch/i)
-  })
-
-  it('refuses to sign when the simulated commitment encodes a different channel', async () => {
-    mockSimulateTransaction.mockResolvedValueOnce(
-      successSimResult(
-        buildCommitment({
-          amount: 1_000_000n,
-          channel: 'CAYGVE5AUQQ2XNXWOXHH5VPGRHYX4APUAOWA4VOBI3VGMOYJ2IJ6VJG5',
-        }),
-      ),
-    )
-
-    const method = makeMethod()
-    const challenge = mockChallenge() // pinned/advertised channel is CHANNEL_ADDRESS
-
-    await expect(
-      method.createCredential({ challenge: challenge as any, context: {} as any }),
-    ).rejects.toThrow(/channel mismatch/i)
-  })
-
-  it('signs when the simulated commitment binds to the intended channel and amount', async () => {
-    mockSimulateTransaction.mockResolvedValueOnce(
-      successSimResult(buildCommitment({ amount: 1_000_000n })),
-    )
-
-    const method = makeMethod()
-    const challenge = mockChallenge()
-
+  /** Extracts the signature the client produced for a challenge. */
+  async function signatureFor(overrides: Record<string, unknown> = {}) {
+    const method = makeMethod({ allowedChannels: [CHANNEL_ADDRESS] })
     const credential = await method.createCredential({
-      challenge: challenge as any,
+      challenge: mockChallenge(overrides) as any,
       context: {} as any,
     })
-
     const token = credential.replace(/^Payment\s+/, '')
     const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf8'))
-    expect(decoded.payload.signature).toMatch(/^[0-9a-f]{128}$/)
-  })
-})
+    return {
+      signature: Buffer.from(decoded.payload.signature, 'hex'),
+      amount: BigInt(decoded.payload.amount),
+    }
+  }
 
-describe('channel client amount validation', () => {
-  it('rejects a malformed counterparty amount with a typed error', async () => {
-    const method = makeMethod({ allowedChannels: [CHANNEL_ADDRESS] })
-    const challenge = mockChallenge({ amount: '100abc' })
+  it('signs a message bound to the intended channel, amount and network', async () => {
+    const { signature, amount } = await signatureFor({ amount: '1000000' })
 
-    await expect(
-      method.createCredential({ challenge: challenge as any, context: {} as any }),
-    ).rejects.toThrow(StellarMppError)
-  })
-
-  it('rejects a counterparty amount exceeding the signed i128 maximum with a typed error', async () => {
-    const method = makeMethod({ allowedChannels: [CHANNEL_ADDRESS] })
-    const challenge = mockChallenge({ amount: (2n ** 127n).toString() })
-
-    await expect(
-      method.createCredential({ challenge: challenge as any, context: {} as any }),
-    ).rejects.toThrow(StellarMppError)
-  })
-
-  it('rejects a cumulativeAmount override exceeding the signed i128 maximum with a typed error', async () => {
-    const method = makeMethod({ allowedChannels: [CHANNEL_ADDRESS] })
-    const challenge = mockChallenge()
-
-    await expect(
-      method.createCredential({
-        challenge: challenge as any,
-        context: { cumulativeAmount: (2n ** 127n).toString() } as any,
-      }),
-    ).rejects.toThrow(StellarMppError)
-  })
-
-  it('rejects a cumulative total whose sum overflows the signed i128 maximum with a typed error', async () => {
-    const store = Store.memory()
-    await store.put(`stellar:channel:client:stellar:testnet:${CHANNEL_ADDRESS}:cumulative`, {
-      amount: (2n ** 127n - 1n).toString(),
+    const intended = buildCommitmentMessage({
+      channel: CHANNEL_ADDRESS,
+      amount,
+      network: STELLAR_TESTNET,
     })
-    const method = makeMethod({ store, allowedChannels: [CHANNEL_ADDRESS] })
-    const challenge = mockChallenge({ amount: '1000000' })
-
-    await expect(
-      method.createCredential({ challenge: challenge as any, context: {} as any }),
-    ).rejects.toThrow(StellarMppError)
+    expect(TEST_KEYPAIR.verify(intended, signature)).toBe(true)
   })
-})
 
-describe('channel client simulation error handling', () => {
-  it('wraps a simulation failure in a typed StellarMppError', async () => {
-    // A counterparty-forced network/channel mismatch makes prepare_commitment
-    // simulation fail. simulateCall throws a SimulationContractError, which is
-    // not a StellarMppError; the client must surface it as a typed error.
-    mockSimulateTransaction.mockResolvedValueOnce({ error: 'contract trapped' })
-    const method = makeMethod({ allowedChannels: [CHANNEL_ADDRESS] })
-    const challenge = mockChallenge()
+  it('produces a signature that does not verify for a different amount', async () => {
+    const { signature, amount } = await signatureFor({ amount: '1000000' })
 
-    await expect(
-      method.createCredential({ challenge: challenge as any, context: {} as any }),
-    ).rejects.toThrow(StellarMppError)
+    const otherAmount = buildCommitmentMessage({
+      channel: CHANNEL_ADDRESS,
+      amount: amount + 1n,
+      network: STELLAR_TESTNET,
+    })
+    expect(TEST_KEYPAIR.verify(otherAmount, signature)).toBe(false)
+  })
+
+  it('produces a signature that does not verify for a different channel', async () => {
+    const { signature, amount } = await signatureFor({ amount: '1000000' })
+
+    const otherChannel = buildCommitmentMessage({
+      channel: 'CAYGVE5AUQQ2XNXWOXHH5VPGRHYX4APUAOWA4VOBI3VGMOYJ2IJ6VJG5',
+      amount,
+      network: STELLAR_TESTNET,
+    })
+    expect(TEST_KEYPAIR.verify(otherChannel, signature)).toBe(false)
+  })
+
+  it('produces a signature that does not verify on a different network', async () => {
+    const { signature, amount } = await signatureFor({ amount: '1000000' })
+
+    const otherNetwork = buildCommitmentMessage({
+      channel: CHANNEL_ADDRESS,
+      amount,
+      network: STELLAR_PUBNET,
+    })
+    expect(TEST_KEYPAIR.verify(otherNetwork, signature)).toBe(false)
+  })
+
+  it('signs without making any RPC call', async () => {
+    mockSimulateTransaction.mockClear()
+    await signatureFor({ amount: '1000000' })
+    expect(mockSimulateTransaction).not.toHaveBeenCalled()
   })
 })

--- a/sdk/src/channel/client/Channel.ts
+++ b/sdk/src/channel/client/Channel.ts
@@ -1,25 +1,10 @@
-import {
-  Account,
-  Contract,
-  Keypair,
-  TransactionBuilder,
-  nativeToScVal,
-  rpc,
-} from '@stellar/stellar-sdk'
+import { Keypair } from '@stellar/stellar-sdk'
 import { Credential, Method, Store } from 'mppx'
 import { z } from 'zod/mini'
-import {
-  ALL_ZEROS,
-  DEFAULT_FEE,
-  NETWORK_PASSPHRASE,
-  type NetworkId,
-  SOROBAN_RPC_URLS,
-} from '../../constants.js'
-import { DEFAULT_SIMULATION_TIMEOUT_MS } from '../../shared/defaults.js'
+import { type NetworkId } from '../../constants.js'
 import { StellarMppError } from '../../shared/errors.js'
-import { simulateCall } from '../../shared/simulate.js'
 import { I128_MAX, resolveNetworkId, validateAmount } from '../../shared/validation.js'
-import { assertCommitmentBinds } from '../commitment.js'
+import { buildCommitmentMessage } from '../commitment.js'
 import { channel as ChannelMethod } from '../Methods.js'
 
 /**
@@ -49,8 +34,6 @@ export function channel(parameters: channel.Parameters) {
     commitmentKey: commitmentKeyParam,
     commitmentSecret,
     onProgress,
-    rpcUrl,
-    simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
     store = Store.memory(),
     allowedChannels,
     allowUnpinnedChannel = false,
@@ -161,56 +144,17 @@ export function channel(parameters: channel.Parameters) {
         cumulativeAmount: cumulativeAmount.toString(),
       })
 
-      // Call prepare_commitment on the channel contract (read-only)
-      const resolvedRpcUrl = rpcUrl ?? SOROBAN_RPC_URLS[network]
-      const networkPassphrase = NETWORK_PASSPHRASE[network]
-      const server = new rpc.Server(resolvedRpcUrl)
-
-      const contract = new Contract(channelAddress)
-      const call = contract.call(
-        'prepare_commitment',
-        nativeToScVal(cumulativeAmount, { type: 'i128' }),
-      )
-
-      // Simulate the call to get the commitment bytes
-      const account = new Account(ALL_ZEROS, '0')
-      const simTx = new TransactionBuilder(account, {
-        fee: DEFAULT_FEE,
-        networkPassphrase,
-      })
-        .addOperation(call)
-        .setTimeout(simulationTimeoutMs / 1000)
-        .build()
-
-      // simulateCall throws its own Simulation* error classes, which do not
-      // extend StellarMppError. The triggering network/channel is
-      // counterparty-influenced, so wrap the failure to keep the public client
-      // API's typed-error contract.
-      let simResult
-      try {
-        simResult = await simulateCall(server, simTx, { timeoutMs: simulationTimeoutMs })
-      } catch (error) {
-        if (error instanceof StellarMppError) throw error
-        throw new StellarMppError(
-          `Channel commitment simulation failed: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-          { details: error instanceof Error ? error.message : String(error) },
-        )
-      }
-
-      // Extract the commitment bytes from the simulation result
-      const returnValue = simResult.result?.retval
-      if (!returnValue) {
-        throw new StellarMppError('prepare_commitment returned no value')
-      }
-
-      const commitmentBytes = returnValue.bytes()
-
-      // The simulation result is not authenticated, so confirm the commitment
-      // we are about to sign matches the channel, amount and network we
-      // intended before signing it.
-      assertCommitmentBinds(commitmentBytes, {
+      // Build the commitment locally. This used to simulate `prepare_commitment`
+      // on the channel contract, but the message is fully determined by the
+      // amount, channel and network the client already chose, so the round trip
+      // bought nothing — a payer no longer needs RPC reachability to sign.
+      //
+      // It also removes a trust step rather than adding one. Simulation results
+      // are unauthenticated, so the fetched bytes had to be checked field by
+      // field (see `assertCommitmentBinds`) before they were safe to sign.
+      // Bytes built here bind to the intended channel, amount and network by
+      // construction.
+      const commitmentBytes = buildCommitmentMessage({
         channel: channelAddress,
         amount: cumulativeAmount,
         network,
@@ -263,9 +207,17 @@ export declare namespace channel {
     commitmentSecret?: string
     /** Stellar Keypair for signing commitments. Provide either this or `commitmentSecret`. */
     commitmentKey?: Keypair
-    /** Custom Soroban RPC URL. Defaults based on network. */
+    /**
+     * @deprecated No longer used. Creating a credential makes no RPC calls —
+     * the commitment is built locally — so this value is ignored. Still
+     * accepted for backwards compatibility; slated for removal in a future minor.
+     */
     rpcUrl?: string
-    /** Simulation timeout in milliseconds. @default 10_000 */
+    /**
+     * @deprecated No longer used. Creating a credential performs no simulation,
+     * so this value is ignored. Still accepted for backwards compatibility;
+     * slated for removal in a future minor.
+     */
     simulationTimeoutMs?: number
     /**
      * Optional persistent store for client-side cumulative amount tracking.
@@ -286,9 +238,9 @@ export declare namespace channel {
      * The client enforces that any channel advertised by the server in the
      * commitment challenge matches one of the addresses in this list.
      *
-     * As a second layer, the client verifies the simulated commitment matches
+     * As a second layer, the commitment the client signs is built locally from
      * the pinned channel, the intended cumulative amount, the expected network,
-     * and the channel domain separator before signing.
+     * and the channel domain separator, so it cannot bind to anything else.
      *
      * Channel pinning is required by default. To disable it, explicitly set
      * `allowUnpinnedChannel: true`.

--- a/sdk/src/channel/commitment.test.ts
+++ b/sdk/src/channel/commitment.test.ts
@@ -1,7 +1,7 @@
 import { Address, Networks, hash, nativeToScVal, xdr } from '@stellar/stellar-sdk'
 import { describe, expect, it } from 'vitest'
 import { STELLAR_PUBNET, STELLAR_TESTNET } from '../constants.js'
-import { assertCommitmentBinds } from './commitment.js'
+import { assertCommitmentBinds, buildCommitmentMessage } from './commitment.js'
 
 const CHANNEL = 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526'
 const OTHER_CHANNEL = 'CAYGVE5AUQQ2XNXWOXHH5VPGRHYX4APUAOWA4VOBI3VGMOYJ2IJ6VJG5'
@@ -136,5 +136,75 @@ describe('assertCommitmentBinds', () => {
         network: STELLAR_TESTNET,
       }),
     ).toThrow(/commitment/i)
+  })
+})
+
+describe('buildCommitmentMessage', () => {
+  // Captured from a real one-way-channel contract deployed on testnet:
+  //   stellar contract invoke --id CAGQ...TSST --network testnet \
+  //     -- prepare_commitment --amount 1000000
+  // Pins the encoding against the contract as of channel.wasm 908a23fd…2326.
+  // The live parity test re-derives this against a fresh deploy; this one keeps
+  // the guarantee under `make check`, where there is no network.
+  const ON_CHAIN_CHANNEL = 'CAGQNIIZVSURKZL57HYJV2FQG77HJR2FZMJIX6ZLTAUINKHH26GYTSST'
+  // prettier-ignore
+  const ON_CHAIN_BYTES_HEX =
+    '0000001100000001000000040000000f00000006616d6f756e7400000000000a000000000000000000000000000f42400000000f000000076368616e6e656c0000000012000000010d06a119aca915657df9f09ae8b037fe74c745cb128bfb2b982886a8e7d78d890000000f00000006646f6d61696e00000000000f000000086368616e636d6d740000000f000000076e6574776f726b000000000d00000020cee0302d59844d32bdca915c8203dd44b33fbb7edc19051ea37abedf28ecd472'
+
+  it('matches bytes returned by the contract on testnet', () => {
+    const local = buildCommitmentMessage({
+      channel: ON_CHAIN_CHANNEL,
+      amount: 1_000_000n,
+      network: STELLAR_TESTNET,
+    })
+
+    expect(local.toString('hex')).toBe(ON_CHAIN_BYTES_HEX)
+  })
+
+  it('round-trips through assertCommitmentBinds', () => {
+    // The encoder and the decoder are independent implementations, so agreeing
+    // on every field is a meaningful cross-check.
+    for (const network of [STELLAR_TESTNET, STELLAR_PUBNET] as const) {
+      for (const amount of [1n, 1_000_000n, 2n ** 100n]) {
+        const bytes = buildCommitmentMessage({ channel: CHANNEL, amount, network })
+        expect(() =>
+          assertCommitmentBinds(bytes, { channel: CHANNEL, amount, network }),
+        ).not.toThrow()
+      }
+    }
+  })
+
+  it('binds the commitment to its channel, amount and network', () => {
+    const bytes = buildCommitmentMessage({
+      channel: CHANNEL,
+      amount: 1_000_000n,
+      network: STELLAR_TESTNET,
+    })
+
+    // A signature over these bytes must not be reusable on another channel,
+    // for another amount, or on another network.
+    expect(() =>
+      assertCommitmentBinds(bytes, {
+        channel: OTHER_CHANNEL,
+        amount: 1_000_000n,
+        network: STELLAR_TESTNET,
+      }),
+    ).toThrow(/channel mismatch/i)
+
+    expect(() =>
+      assertCommitmentBinds(bytes, {
+        channel: CHANNEL,
+        amount: 999_999n,
+        network: STELLAR_TESTNET,
+      }),
+    ).toThrow(/amount mismatch/i)
+
+    expect(() =>
+      assertCommitmentBinds(bytes, {
+        channel: CHANNEL,
+        amount: 1_000_000n,
+        network: STELLAR_PUBNET,
+      }),
+    ).toThrow(/network mismatch/i)
   })
 })

--- a/sdk/src/channel/commitment.ts
+++ b/sdk/src/channel/commitment.ts
@@ -1,4 +1,4 @@
-import { hash, scValToNative, xdr } from '@stellar/stellar-sdk'
+import { Address, hash, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk'
 import { NETWORK_PASSPHRASE, type NetworkId } from '../constants.js'
 import { StellarMppError } from '../shared/errors.js'
 
@@ -16,6 +16,51 @@ export interface ExpectedCommitment {
   amount: bigint
   /** Network the commitment must be scoped to. */
   network: NetworkId
+}
+
+/**
+ * Builds the commitment message locally, byte-for-byte identical to what the
+ * one-way-channel contract's `prepare_commitment` returns.
+ *
+ * The message is the XDR of an `ScVal::Map` with four entries — `amount`,
+ * `channel`, `domain`, `network` — which Soroban requires in ascending key
+ * order (already alphabetical here). Every field is known before a request
+ * arrives: the amount comes from the voucher, the channel and network from
+ * configuration, and the domain is a constant. Nothing about the message
+ * depends on chain state, so constructing it needs no RPC.
+ *
+ * Building rather than fetching also removes a trust dependency: bytes fetched
+ * from an unauthenticated simulation must be checked field by field (see
+ * {@link assertCommitmentBinds}) before they can be signed or verified against.
+ * Bytes built here are correct by construction.
+ *
+ * The one risk is drifting from the contract's encoding. The live parity test
+ * in `integration/live` guards that by comparing this output against a real
+ * `prepare_commitment` call.
+ *
+ * @param expected - The channel, amount and network to bind the commitment to.
+ * @returns XDR-encoded commitment bytes — the exact message the client signs.
+ */
+export function buildCommitmentMessage(expected: ExpectedCommitment): Buffer {
+  const networkId = hash(Buffer.from(NETWORK_PASSPHRASE[expected.network]))
+  return xdr.ScVal.scvMap([
+    new xdr.ScMapEntry({
+      key: nativeToScVal('amount', { type: 'symbol' }),
+      val: nativeToScVal(expected.amount, { type: 'i128' }),
+    }),
+    new xdr.ScMapEntry({
+      key: nativeToScVal('channel', { type: 'symbol' }),
+      val: new Address(expected.channel).toScVal(),
+    }),
+    new xdr.ScMapEntry({
+      key: nativeToScVal('domain', { type: 'symbol' }),
+      val: nativeToScVal(COMMITMENT_DOMAIN, { type: 'symbol' }),
+    }),
+    new xdr.ScMapEntry({
+      key: nativeToScVal('network', { type: 'symbol' }),
+      val: xdr.ScVal.scvBytes(networkId),
+    }),
+  ]).toXDR()
 }
 
 /**

--- a/sdk/src/channel/integration/live/accepts/commitment-parity.test.ts
+++ b/sdk/src/channel/integration/live/accepts/commitment-parity.test.ts
@@ -1,0 +1,115 @@
+import {
+  Account,
+  Address,
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+} from '@stellar/stellar-sdk'
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+  ALL_ZEROS,
+  DEFAULT_FEE,
+  NETWORK_PASSPHRASE,
+  SOROBAN_RPC_URLS,
+  STELLAR_TESTNET,
+} from '../../../../constants.js'
+import { buildCommitmentMessage } from '../../../commitment.js'
+
+/**
+ * Contract-drift guard for {@link buildCommitmentMessage}.
+ *
+ * The server no longer calls `prepare_commitment` to obtain the message it
+ * verifies signatures against — it builds those bytes locally. That is only
+ * safe while the local encoding agrees with the contract's, so this test
+ * compares them against a real deployed channel.
+ *
+ * Asking the contract was the original justification for the RPC call. This
+ * test is what replaces that guarantee: it moves the check from every voucher
+ * at runtime to once per CI run.
+ *
+ * Requires `CHANNEL_CONTRACT` to point at a deployed one-way-channel contract
+ * on testnet. Skips when unset so the suite stays runnable without one.
+ */
+const CHANNEL_CONTRACT = process.env.CHANNEL_CONTRACT
+
+describe.skipIf(!CHANNEL_CONTRACT)('commitment encoding parity with the contract', () => {
+  let server: rpc.Server
+
+  beforeAll(() => {
+    server = new rpc.Server(SOROBAN_RPC_URLS[STELLAR_TESTNET])
+  })
+
+  /** Calls `prepare_commitment(amount)` on-chain and returns the raw bytes. */
+  async function prepareCommitmentOnChain(amount: bigint): Promise<Buffer> {
+    const contract = new Contract(CHANNEL_CONTRACT!)
+    const tx = new TransactionBuilder(new Account(ALL_ZEROS, '0'), {
+      fee: DEFAULT_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE[STELLAR_TESTNET],
+    })
+      .addOperation(contract.call('prepare_commitment', nativeToScVal(amount, { type: 'i128' })))
+      .setTimeout(30)
+      .build()
+
+    const sim = await server.simulateTransaction(tx)
+    if (rpc.Api.isSimulationError(sim)) {
+      throw new Error(`prepare_commitment simulation failed: ${sim.error}`)
+    }
+    const retval = (sim as rpc.Api.SimulateTransactionSuccessResponse).result?.retval
+    if (!retval) throw new Error('prepare_commitment returned no value')
+    return Buffer.from(retval.bytes())
+  }
+
+  // Spread across the i128 range: a boundary value, a typical voucher, and a
+  // large one, since encoding bugs tend to hide at width transitions.
+  const AMOUNTS = [1n, 1_000_000n, 9_999_999_999n, 2n ** 64n]
+
+  it.each(AMOUNTS)('matches prepare_commitment(%s) byte-for-byte', async (amount) => {
+    const [onChain, local] = [
+      await prepareCommitmentOnChain(amount),
+      buildCommitmentMessage({
+        channel: CHANNEL_CONTRACT!,
+        amount,
+        network: STELLAR_TESTNET,
+      }),
+    ]
+
+    expect(local.toString('hex')).toBe(onChain.toString('hex'))
+  })
+
+  it('produces bytes a real keypair signature verifies against', async () => {
+    // End-to-end shape of the server's check: sign the locally-built message,
+    // verify with only the public key — exactly what verifyCommitmentSignature
+    // does, with no RPC involved in the verification itself.
+    const kp = Keypair.random()
+    const amount = 4_242_424n
+
+    const message = buildCommitmentMessage({
+      channel: CHANNEL_CONTRACT!,
+      amount,
+      network: STELLAR_TESTNET,
+    })
+    expect(message.toString('hex')).toBe((await prepareCommitmentOnChain(amount)).toString('hex'))
+
+    const signature = kp.sign(message)
+    expect(Keypair.fromPublicKey(kp.publicKey()).verify(message, signature)).toBe(true)
+  })
+
+  it('binds to the channel address', async () => {
+    // A different channel must produce different bytes, so a signature cannot
+    // be replayed across channels.
+    const other = Address.contract(Buffer.alloc(32, 7)).toString()
+    const amount = 1_000_000n
+
+    expect(
+      buildCommitmentMessage({
+        channel: CHANNEL_CONTRACT!,
+        amount,
+        network: STELLAR_TESTNET,
+      }).toString('hex'),
+    ).not.toBe(
+      buildCommitmentMessage({ channel: other, amount, network: STELLAR_TESTNET }).toString('hex'),
+    )
+  })
+})

--- a/sdk/src/channel/integration/mocked/rejects/cross-process-replay.test.ts
+++ b/sdk/src/channel/integration/mocked/rejects/cross-process-replay.test.ts
@@ -1,5 +1,7 @@
 import { Keypair } from '@stellar/stellar-sdk'
 import { Challenge, Credential, Store } from 'mppx'
+import { STELLAR_TESTNET } from '../../../../constants.js'
+import { buildCommitmentMessage } from '../../../commitment.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Cross-process replay protection: two independent server
@@ -40,7 +42,13 @@ function makeSignedCredential(opts: {
   challengeAmount: string
   previousCumulative?: string
 }) {
-  const sig = COMMITMENT_KEY.sign(opts.commitmentBytes)
+  const sig = COMMITMENT_KEY.sign(
+    buildCommitmentMessage({
+      channel: CHANNEL_ADDRESS,
+      amount: opts.cumulativeAmount,
+      network: STELLAR_TESTNET,
+    }),
+  )
   const sigHex = Buffer.from(sig).toString('hex')
   const challenge = Challenge.from({
     id: `test-${crypto.randomUUID()}`,

--- a/sdk/src/channel/integration/mocked/rejects/settling-window.test.ts
+++ b/sdk/src/channel/integration/mocked/rejects/settling-window.test.ts
@@ -1,5 +1,7 @@
 import { Account, Keypair } from '@stellar/stellar-sdk'
 import { Challenge, Credential, Store } from 'mppx'
+import { STELLAR_TESTNET } from '../../../../constants.js'
+import { buildCommitmentMessage } from '../../../commitment.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // End-to-end settling-window rejection.
@@ -56,7 +58,15 @@ function makeSignedCredential(opts: {
   challengeAmount: string
   previousCumulative?: string
 }) {
-  const sigHex = Buffer.from(COMMITMENT_KEY.sign(opts.commitmentBytes)).toString('hex')
+  const sigHex = Buffer.from(
+    COMMITMENT_KEY.sign(
+      buildCommitmentMessage({
+        channel: CHANNEL_ADDRESS,
+        amount: opts.cumulativeAmount,
+        network: STELLAR_TESTNET,
+      }),
+    ),
+  ).toString('hex')
   const challenge = Challenge.from({
     id: `test-${crypto.randomUUID()}`,
     realm: 'localhost',

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -1,4 +1,6 @@
 import { Account, Address, Keypair, Networks, Transaction, xdr } from '@stellar/stellar-sdk'
+import { STELLAR_TESTNET } from '../../constants.js'
+import { buildCommitmentMessage } from '../commitment.js'
 import { Challenge, Credential, Store } from 'mppx'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -115,12 +117,19 @@ function makeCredential(opts: {
 /** Build a credential with a real ed25519 signature over `commitmentBytes`. */
 function makeSignedCredential(opts: {
   action?: 'voucher' | 'close'
-  commitmentBytes: Buffer
   cumulativeAmount: bigint
   challengeAmount: string
   previousCumulative?: string
 }) {
-  const sig = COMMITMENT_KEY.sign(opts.commitmentBytes)
+  // The server builds this message locally, so a credential is only valid when
+  // signed over the real encoding for its amount — not over arbitrary bytes.
+  const sig = COMMITMENT_KEY.sign(
+    buildCommitmentMessage({
+      channel: CHANNEL_ADDRESS,
+      amount: opts.cumulativeAmount,
+      network: STELLAR_TESTNET,
+    }),
+  )
   const sigHex = Buffer.from(sig).toString('hex')
   const challenge = Challenge.from({
     id: `test-${crypto.randomUUID()}`,
@@ -280,7 +289,6 @@ describe('stellar server channel', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -631,7 +639,6 @@ describe('stellar server channel verification', () => {
     await store.put(`stellar:channel:cumulative:${CHANNEL_ADDRESS}`, { amount: '10000' })
 
     const credential = makeSignedCredential({
-      commitmentBytes: Buffer.from('non-monotonic-precheck-bytes'),
       cumulativeAmount: 1000n, // below the stored cumulative of 10000
       challengeAmount: '1000',
       previousCumulative: '10000',
@@ -662,7 +669,6 @@ describe('stellar server channel verification', () => {
     const cumulativeKey = `stellar:channel:cumulative:${CHANNEL_ADDRESS}`
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -722,7 +728,6 @@ describe('stellar server channel verification', () => {
     const store = Store.memory()
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -755,7 +760,6 @@ describe('stellar server channel verification', () => {
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -791,7 +795,6 @@ describe('stellar server channel verification', () => {
     // Close is rejected because no envelope signer is configured.
     const closeCred = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -805,7 +808,6 @@ describe('stellar server channel verification', () => {
     // A subsequent voucher still succeeds — the channel was not left settling.
     const voucherCred = makeSignedCredential({
       action: 'voucher',
-      commitmentBytes,
       cumulativeAmount: 2000000n,
       challengeAmount: '2000000',
     })
@@ -835,7 +837,6 @@ describe('stellar server channel verification', () => {
     // Close passes validation but settlement fails before broadcast.
     const closeCred = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -850,7 +851,6 @@ describe('stellar server channel verification', () => {
     // A subsequent voucher above the attempted close amount still succeeds.
     const voucherCred = makeSignedCredential({
       action: 'voucher',
-      commitmentBytes,
       cumulativeAmount: 6000000n,
       challengeAmount: '1000000',
     })
@@ -873,7 +873,6 @@ describe('stellar server channel verification', () => {
     const store = Store.memory()
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -920,7 +919,6 @@ describe('stellar server channel verification', () => {
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -954,7 +952,6 @@ describe('stellar server channel verification', () => {
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -986,7 +983,6 @@ describe('stellar server channel verification', () => {
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -1020,7 +1016,6 @@ describe('stellar server channel verification', () => {
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -1058,7 +1053,6 @@ describe('stellar server channel verification', () => {
     const store = Store.memory()
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -1111,7 +1105,6 @@ describe('stellar server channel dispute detection', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1150,7 +1143,6 @@ describe('stellar server channel dispute detection', () => {
     const onDisputeDetected = vi.fn()
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1182,7 +1174,6 @@ describe('stellar server channel dispute detection', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1221,7 +1212,6 @@ describe('stellar server channel dispute detection', () => {
     const store = Store.memory()
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1255,7 +1245,6 @@ describe('stellar server channel dispute detection', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1310,7 +1299,6 @@ describe('stellar server channel dispute detection', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1348,7 +1336,6 @@ describe('stellar server channel dispute detection', () => {
     const onDisputeDetected = vi.fn()
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1386,7 +1373,6 @@ describe('stellar server channel dispute detection', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 5000000n, // exactly at balance
       challengeAmount: '5000000',
     })
@@ -1422,7 +1408,6 @@ describe('stellar server channel dispute detection', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1656,7 +1641,6 @@ describe('channel challenge replay across instances sharing a store', () => {
 
     // Same credential sent to both instances — only one should succeed
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -1700,7 +1684,6 @@ describe('channel challenge replay across instances sharing a store', () => {
     })
 
     const credential = makeSignedCredential({
-      commitmentBytes: commitmentBytes1,
       cumulativeAmount: 500000n,
       challengeAmount: '500000',
     })
@@ -1795,7 +1778,6 @@ describe('channel vouchers during close settlement window', () => {
 
     const closeCredential = makeSignedCredential({
       action: 'close',
-      commitmentBytes: closeBytes,
       cumulativeAmount: 100n,
       challengeAmount: '100',
     })
@@ -1808,7 +1790,6 @@ describe('channel vouchers during close settlement window', () => {
 
     const voucherCredential = makeSignedCredential({
       action: 'voucher',
-      commitmentBytes: voucherBytes,
       cumulativeAmount: 110n,
       challengeAmount: '10',
       previousCumulative: '100',
@@ -1845,7 +1826,6 @@ describe('channel vouchers during close settlement window', () => {
 
     const credential = makeSignedCredential({
       action: 'voucher',
-      commitmentBytes,
       cumulativeAmount: 6000000n,
       challengeAmount: '1000000',
       previousCumulative: '5000000',
@@ -1882,7 +1862,6 @@ describe('channel vouchers during close settlement window', () => {
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 6000000n,
       challengeAmount: '1000000',
       previousCumulative: '5000000',
@@ -1990,7 +1969,6 @@ describe('channel vouchers during close settlement window', () => {
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -2023,7 +2001,6 @@ describe('channel vouchers during close settlement window', () => {
 
     const voucherCredential = makeSignedCredential({
       action: 'voucher',
-      commitmentBytes: voucherBytes,
       cumulativeAmount: 6000000n,
       challengeAmount: '1000000',
       previousCumulative: '5000000',
@@ -2079,7 +2056,6 @@ describe('channel vouchers during close settlement window', () => {
     // First close settlement — should succeed, charges maxFeeBumpStroops against budget
     const credential1 = makeSignedCredential({
       action: 'close',
-      commitmentBytes: bytes1,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -2109,7 +2085,6 @@ describe('channel vouchers during close settlement window', () => {
     // Second close settlement within window — should fail (budget exceeded)
     const credential2 = makeSignedCredential({
       action: 'close',
-      commitmentBytes: bytes2,
       cumulativeAmount: 2000000n,
       challengeAmount: '1000000',
     })
@@ -2175,7 +2150,6 @@ describe('channel vouchers during close settlement window', () => {
     for (let i = 0; i < allowedSettlements; i++) {
       const credential = makeSignedCredential({
         action: 'close',
-        commitmentBytes: settlementBytes[i],
         cumulativeAmount: BigInt((i + 1) * 1_000_000),
         challengeAmount: '1000000',
       })
@@ -2201,7 +2175,6 @@ describe('channel vouchers during close settlement window', () => {
     // The next settlement exceeds the cap and must be rejected before broadcast.
     const overBudget = makeSignedCredential({
       action: 'close',
-      commitmentBytes: settlementBytes[allowedSettlements],
       cumulativeAmount: BigInt((allowedSettlements + 1) * 1_000_000),
       challengeAmount: '1000000',
     })
@@ -2261,7 +2234,6 @@ describe('channel vouchers during close settlement window', () => {
       // First close settlement at t=0
       const credential1 = makeSignedCredential({
         action: 'close',
-        commitmentBytes: windowBytes1,
         cumulativeAmount: 1000000n,
         challengeAmount: '1000000',
       })
@@ -2290,7 +2262,6 @@ describe('channel vouchers during close settlement window', () => {
       // Second close settlement after window elapses — should succeed and start new window
       const credential2 = makeSignedCredential({
         action: 'close',
-        commitmentBytes: windowBytes2,
         cumulativeAmount: 2000000n,
         challengeAmount: '1000000',
       })
@@ -2346,7 +2317,6 @@ describe('channel vouchers during close settlement window', () => {
     // First close
     const credential1 = makeSignedCredential({
       action: 'close',
-      commitmentBytes: noBudgetBytes1,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -2368,7 +2338,6 @@ describe('channel vouchers during close settlement window', () => {
     // Second close — no budget so should succeed
     const credential2 = makeSignedCredential({
       action: 'close',
-      commitmentBytes: noBudgetBytes2,
       cumulativeAmount: 2000000n,
       challengeAmount: '1000000',
     })
@@ -2415,7 +2384,6 @@ describe('channel vouchers during close settlement window', () => {
     // First close settlement
     const credential1 = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -2497,7 +2465,13 @@ describe('atomic challenge replay protection (channel)', () => {
     })
 
     const amount = '200'
-    const signature = COMMITMENT_KEY.sign(Buffer.from('test-commitment-bytes')).toString('hex')
+    const signature = COMMITMENT_KEY.sign(
+      buildCommitmentMessage({
+        channel: CHANNEL_ADDRESS,
+        amount: BigInt(amount),
+        network: STELLAR_TESTNET,
+      }),
+    ).toString('hex')
 
     const cred = Object.assign(
       Credential.from({
@@ -2682,7 +2656,13 @@ describe('atomic challenge replay protection (channel)', () => {
 
     // Commitment of 200 is > 100 and covers 100 + 50 = 150, should succeed
     const amount = '200'
-    const signature = COMMITMENT_KEY.sign(Buffer.from('test-commitment-bytes')).toString('hex')
+    const signature = COMMITMENT_KEY.sign(
+      buildCommitmentMessage({
+        channel: CHANNEL_ADDRESS,
+        amount: BigInt(amount),
+        network: STELLAR_TESTNET,
+      }),
+    ).toString('hex')
 
     const cred = Object.assign(
       Credential.from({
@@ -2739,7 +2719,6 @@ describe('channel server recipient pinning (on-chain payout address validation)'
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -2762,7 +2741,6 @@ describe('channel server recipient pinning (on-chain payout address validation)'
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -2822,7 +2800,6 @@ describe('channel server currency pinning (on-chain token validation)', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -2845,7 +2822,6 @@ describe('channel server currency pinning (on-chain token validation)', () => {
     mockSimulateTransaction.mockResolvedValueOnce(successSimResult(commitmentBytes))
 
     const credential = makeSignedCredential({
-      commitmentBytes,
       cumulativeAmount: 1000000n,
       challengeAmount: '1000000',
     })
@@ -2940,7 +2916,6 @@ describe('channel server close transaction inspection (auth-tree injection)', ()
 
     const credential = makeSignedCredential({
       action: 'close',
-      commitmentBytes,
       cumulativeAmount: 5000000n,
       challengeAmount: '5000000',
     })
@@ -2984,6 +2959,8 @@ describe('channel server close transaction inspection (auth-tree injection)', ()
 // ---------------------------------------------------------------------------
 
 describe('channel verification runs RPC outside the cumulative lock', () => {
+  // Commitment signatures are now verified against a locally-built message, so
+  // the only RPC left in the verification path is the on-chain state read.
   const COMMITMENT_BYTES = Buffer.from('unlocked-rpc-commitment-bytes')
 
   // These tests swap in delayed mock implementations. Mocks are not auto-cleared
@@ -2993,28 +2970,6 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
     mockGetChannelState.mockReset()
     mockGetChannelState.mockResolvedValue(mockHealthyChannelState())
   })
-
-  /**
-   * Replaces the simulate mock with a slow one that records how many
-   * simulations are in flight at once.
-   *
-   * @returns A live counter — read `max` after the verifies settle.
-   */
-  function trackSimulateConcurrency(delayMs = 50) {
-    const counter = { inFlight: 0, max: 0 }
-    mockSimulateTransaction.mockReset()
-    mockSimulateTransaction.mockImplementation(() => {
-      counter.inFlight++
-      counter.max = Math.max(counter.max, counter.inFlight)
-      return new Promise((resolve) =>
-        setTimeout(() => {
-          counter.inFlight--
-          resolve(successSimResult(COMMITMENT_BYTES))
-        }, delayMs),
-      )
-    })
-    return counter
-  }
 
   /**
    * Replaces the on-chain state mock with a slow one that records how many
@@ -3048,40 +3003,17 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
   function makeConcurrentCredentials(amounts: bigint[]) {
     return amounts.map((amount) =>
       makeSignedCredential({
-        commitmentBytes: COMMITMENT_BYTES,
         cumulativeAmount: amount,
         challengeAmount: amount.toString(),
       }),
     )
   }
 
-  it('overlaps simulations across concurrent verifies instead of serializing them', async () => {
-    // The regression this guards: when the signature simulation ran under the
-    // cumulative lock, only one could ever be in flight, so a slow RPC stalled
-    // every concurrent payer on the channel.
-    const counter = trackSimulateConcurrency()
-
-    const method = channel({
-      channel: CHANNEL_ADDRESS,
-      checkOnChainState: false,
-      commitmentKey: COMMITMENT_KEY,
-      store: Store.memory(),
-    })
-
-    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
-    await Promise.allSettled(
-      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
-    )
-
-    expect(counter.max).toBe(4)
-  })
-
   it('overlaps on-chain state reads across concurrent verifies', async () => {
     // Same guarantee as above, for the other RPC path. `verifyOnChainState`
     // costs several calls, so serializing it under the lock would stall
     // concurrent payers just as badly — and the checkOnChainState: false tests
     // above cannot detect that.
-    trackSimulateConcurrency(0)
     const stateReads = trackStateReadConcurrency()
 
     const method = channel({
@@ -3103,7 +3035,6 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
 
   it('bounds concurrent on-chain state reads by simulateMaxConcurrent', async () => {
     // The semaphore wraps both RPC paths, so it caps state reads too.
-    trackSimulateConcurrency(0)
     const stateReads = trackStateReadConcurrency()
 
     const method = channel({
@@ -3122,33 +3053,10 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
     expect(stateReads.max).toBe(2)
   })
 
-  it('bounds concurrent simulations by simulateMaxConcurrent', async () => {
-    // With the lock no longer serializing RPC, the semaphore is the only cap on
-    // fan-out onto the RPC provider.
-    const counter = trackSimulateConcurrency()
-
-    const method = channel({
-      channel: CHANNEL_ADDRESS,
-      checkOnChainState: false,
-      commitmentKey: COMMITMENT_KEY,
-      store: Store.memory(),
-      simulateMaxConcurrent: 2,
-    })
-
-    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
-    await Promise.allSettled(
-      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
-    )
-
-    expect(counter.max).toBe(2)
-  })
-
   it('still admits exactly one of several concurrent credentials at the same cumulative', async () => {
     // Unlocked RPC must not weaken monotonicity: all four clear the pre-RPC
     // short-circuit against a cumulative of 0, then serialize in the locked
     // commit, where only the first can advance the cumulative.
-    trackSimulateConcurrency()
-
     const method = channel({
       channel: CHANNEL_ADDRESS,
       checkOnChainState: false,

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -2978,3 +2978,113 @@ describe('channel server close transaction inspection (auth-tree injection)', ()
     expect(mockSendTransaction).not.toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// RPC-outside-the-lock tests
+// ---------------------------------------------------------------------------
+
+describe('channel verification runs RPC outside the cumulative lock', () => {
+  const COMMITMENT_BYTES = Buffer.from('unlocked-rpc-commitment-bytes')
+
+  /**
+   * Replaces the simulate mock with a slow one that records how many
+   * simulations are in flight at once.
+   *
+   * @returns A live counter — read `max` after the verifies settle.
+   */
+  function trackSimulateConcurrency(delayMs = 50) {
+    const counter = { inFlight: 0, max: 0 }
+    mockSimulateTransaction.mockReset()
+    mockSimulateTransaction.mockImplementation(() => {
+      counter.inFlight++
+      counter.max = Math.max(counter.max, counter.inFlight)
+      return new Promise((resolve) =>
+        setTimeout(() => {
+          counter.inFlight--
+          resolve(successSimResult(COMMITMENT_BYTES))
+        }, delayMs),
+      )
+    })
+    return counter
+  }
+
+  /** Credentials all signed over the same bytes, so each passes the mocked
+   *  `prepare_commitment` signature check regardless of its amount. */
+  function makeConcurrentCredentials(amounts: bigint[]) {
+    return amounts.map((amount) =>
+      makeSignedCredential({
+        commitmentBytes: COMMITMENT_BYTES,
+        cumulativeAmount: amount,
+        challengeAmount: amount.toString(),
+      }),
+    )
+  }
+
+  it('overlaps simulations across concurrent verifies instead of serializing them', async () => {
+    // The regression this guards: when the signature simulation ran under the
+    // cumulative lock, only one could ever be in flight, so a slow RPC stalled
+    // every concurrent payer on the channel.
+    const counter = trackSimulateConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: false,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(counter.max).toBe(4)
+  })
+
+  it('bounds concurrent simulations by simulateMaxConcurrent', async () => {
+    // With the lock no longer serializing RPC, the semaphore is the only cap on
+    // fan-out onto the RPC provider.
+    const counter = trackSimulateConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: false,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+      simulateMaxConcurrent: 2,
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(counter.max).toBe(2)
+  })
+
+  it('still admits exactly one of several concurrent credentials at the same cumulative', async () => {
+    // Unlocked RPC must not weaken monotonicity: all four clear the pre-RPC
+    // short-circuit against a cumulative of 0, then serialize in the locked
+    // commit, where only the first can advance the cumulative.
+    trackSimulateConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: false,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 1000n, 1000n, 1000n])
+    const results = await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1)
+    for (const rejected of results.filter((r) => r.status === 'rejected')) {
+      expect((rejected as PromiseRejectedResult).reason.message).toContain(
+        'must be greater than previous cumulative',
+      )
+    }
+  })
+})

--- a/sdk/src/channel/server/Channel.test.ts
+++ b/sdk/src/channel/server/Channel.test.ts
@@ -1,6 +1,6 @@
 import { Account, Address, Keypair, Networks, Transaction, xdr } from '@stellar/stellar-sdk'
 import { Challenge, Credential, Store } from 'mppx'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Hoisted mock stubs — accessible inside the vi.mock factory
 const mockGetAccount = vi.fn()
@@ -2986,6 +2986,14 @@ describe('channel server close transaction inspection (auth-tree injection)', ()
 describe('channel verification runs RPC outside the cumulative lock', () => {
   const COMMITMENT_BYTES = Buffer.from('unlocked-rpc-commitment-bytes')
 
+  // These tests swap in delayed mock implementations. Mocks are not auto-cleared
+  // in this file, so restore the module-level defaults rather than leaving a
+  // slow getChannelState behind for whatever test is added next.
+  afterEach(() => {
+    mockGetChannelState.mockReset()
+    mockGetChannelState.mockResolvedValue(mockHealthyChannelState())
+  })
+
   /**
    * Replaces the simulate mock with a slow one that records how many
    * simulations are in flight at once.
@@ -3002,6 +3010,33 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
         setTimeout(() => {
           counter.inFlight--
           resolve(successSimResult(COMMITMENT_BYTES))
+        }, delayMs),
+      )
+    })
+    return counter
+  }
+
+  /**
+   * Replaces the on-chain state mock with a slow one that records how many
+   * state reads are in flight at once.
+   *
+   * `verifyOnChainState` is a separate, multi-call RPC path from the
+   * signature simulation, so it needs its own overlap assertion — tests that
+   * run with `checkOnChainState: false` would still pass if this path alone
+   * were moved back under the cumulative lock.
+   *
+   * @returns A live counter — read `max` after the verifies settle.
+   */
+  function trackStateReadConcurrency(delayMs = 50) {
+    const counter = { inFlight: 0, max: 0 }
+    mockGetChannelState.mockReset()
+    mockGetChannelState.mockImplementation(() => {
+      counter.inFlight++
+      counter.max = Math.max(counter.max, counter.inFlight)
+      return new Promise((resolve) =>
+        setTimeout(() => {
+          counter.inFlight--
+          resolve(mockHealthyChannelState())
         }, delayMs),
       )
     })
@@ -3039,6 +3074,52 @@ describe('channel verification runs RPC outside the cumulative lock', () => {
     )
 
     expect(counter.max).toBe(4)
+  })
+
+  it('overlaps on-chain state reads across concurrent verifies', async () => {
+    // Same guarantee as above, for the other RPC path. `verifyOnChainState`
+    // costs several calls, so serializing it under the lock would stall
+    // concurrent payers just as badly — and the checkOnChainState: false tests
+    // above cannot detect that.
+    trackSimulateConcurrency(0)
+    const stateReads = trackStateReadConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: true,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    // All four reach the state read together: one verification progresses into
+    // it while the others' reads are still pending.
+    expect(stateReads.max).toBe(4)
+  })
+
+  it('bounds concurrent on-chain state reads by simulateMaxConcurrent', async () => {
+    // The semaphore wraps both RPC paths, so it caps state reads too.
+    trackSimulateConcurrency(0)
+    const stateReads = trackStateReadConcurrency()
+
+    const method = channel({
+      channel: CHANNEL_ADDRESS,
+      checkOnChainState: true,
+      commitmentKey: COMMITMENT_KEY,
+      store: Store.memory(),
+      simulateMaxConcurrent: 2,
+    })
+
+    const credentials = makeConcurrentCredentials([1000n, 2000n, 3000n, 4000n])
+    await Promise.allSettled(
+      credentials.map((c) => method.verify({ credential: c as any, request: c.challenge.request })),
+    )
+
+    expect(stateReads.max).toBe(2)
   })
 
   it('bounds concurrent simulations by simulateMaxConcurrent', async () => {

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -1,5 +1,4 @@
 import {
-  Account,
   Contract,
   FeeBumpTransaction,
   Keypair,
@@ -10,7 +9,6 @@ import {
 } from '@stellar/stellar-sdk'
 import { Method, Receipt, Store } from 'mppx'
 import {
-  ALL_ZEROS,
   DEFAULT_DECIMALS,
   DEFAULT_FEE,
   DEFAULT_TIMEOUT,
@@ -35,9 +33,9 @@ import { resolveKeypair } from '../../shared/keypairs.js'
 import { noopLogger, type Logger } from '../../shared/logger.js'
 import { pollTransaction } from '../../shared/poll.js'
 import { toBaseUnits } from '../../shared/units.js'
-import { simulateCall } from '../../shared/simulate.js'
 import { validateAmount, validateHexSignature } from '../../shared/validation.js'
 import { verifyInvokeContractOp } from '../../shared/verify-invoke.js'
+import { buildCommitmentMessage } from '../commitment.js'
 import { channel as ChannelMethod } from '../Methods.js'
 import { getChannelState, type ChannelState } from './State.js'
 
@@ -158,8 +156,8 @@ export function channel(parameters: channel.Parameters) {
   const networkPassphrase = NETWORK_PASSPHRASE[network]
   const rpcServer = new rpc.Server(resolvedRpcUrl)
   const pollSemaphore = new Semaphore(pollMaxConcurrent)
-  // Bounds credential verifications holding RPC simulations concurrently. The
-  // simulations run outside cumulativeLock, so this is the only cap on fan-out.
+  // Bounds credential verifications holding an on-chain state read concurrently.
+  // The reads run outside cumulativeLock, so this is the only cap on fan-out.
   const simulateSemaphore = new Semaphore(simulateMaxConcurrent)
 
   // Parse the commitment public key (accepts G... Stellar public key string or Keypair)
@@ -414,24 +412,26 @@ export function channel(parameters: channel.Parameters) {
       throw preCheckError
     }
 
-    // Bound concurrent RPC. The cumulative lock used to cap simulations at one
-    // in flight as a side effect of serialising validation; now that the RPC
-    // runs unlocked, that cap has to be explicit or a burst of credentials fans
-    // straight out onto the RPC provider.
-    await simulateSemaphore.acquire()
-    try {
-      // Verify the commitment signature before anything writes channel state.
-      await verifyCommitmentSignature(commitmentAmount, signatureBytes)
+    // Verify the commitment signature before anything writes channel state.
+    // Local and CPU-only, so it runs outside the semaphore below: a forged
+    // voucher is rejected without ever occupying one of the bounded RPC slots.
+    verifyCommitmentSignature(commitmentAmount, signatureBytes)
 
-      // Query on-chain state only after the commitment signature is proven
-      // authentic. The state read costs several RPC calls; gating it behind the
-      // cheaper signature check stops a forged voucher from amplifying into the
-      // full state query.
-      if (checkOnChainState) {
+    // Query on-chain state only after the signature is proven authentic. The
+    // state read costs several RPC calls; gating it behind the cheap signature
+    // check stops a forged voucher from amplifying into the full state query.
+    //
+    // Bound the concurrency explicitly. The cumulative lock used to cap these
+    // reads at one in flight as a side effect of serialising validation; now
+    // that they run unlocked, a burst of credentials would otherwise fan
+    // straight out onto the RPC provider.
+    if (checkOnChainState) {
+      await simulateSemaphore.acquire()
+      try {
         await verifyOnChainState(commitmentAmount)
+      } finally {
+        simulateSemaphore.release()
       }
-    } finally {
-      simulateSemaphore.release()
     }
 
     // A close can only be settled by a server configured with an envelope signer.
@@ -680,41 +680,31 @@ export function channel(parameters: channel.Parameters) {
   }
 
   /**
-   * Simulates `prepare_commitment` on the channel contract and verifies
-   * the ed25519 signature against the returned commitment bytes.
+   * Builds the commitment message locally and verifies the ed25519 signature
+   * against it.
    *
-   * @throws {ChannelVerificationError} If the simulation returns no value
-   *   or the signature does not match.
+   * This used to simulate `prepare_commitment` over RPC to obtain the signed
+   * message. It no longer does. The message is fully determined by the amount,
+   * the configured channel and network, and a constant domain separator — all
+   * known before the request arrives — so the round trip bought nothing and
+   * cost up to `simulationTimeoutMs` per voucher.
+   *
+   * Dropping it also closes a trust gap. The simulation was unauthenticated, so
+   * an RPC that returned bytes for a *different* amount would have had a
+   * client's signature checked against those bytes while the server credited
+   * the amount from the payload. Bytes built here cannot disagree with the
+   * amount being credited.
+   *
+   * @throws {ChannelVerificationError} If the signature does not match.
    */
-  async function verifyCommitmentSignature(
-    commitmentAmount: bigint,
-    signatureBytes: Buffer,
-  ): Promise<void> {
+  function verifyCommitmentSignature(commitmentAmount: bigint, signatureBytes: Buffer): void {
     logger.debug(`${LOG_PREFIX} Verifying commitment signature...`)
-    const contract = new Contract(channelAddress)
-    const call = contract.call(
-      'prepare_commitment',
-      nativeToScVal(commitmentAmount, { type: 'i128' }),
-    )
-
-    const account = new Account(ALL_ZEROS, '0')
-    const simTx = new TransactionBuilder(account, {
-      fee: DEFAULT_FEE,
-      networkPassphrase,
+    const commitmentBytes = buildCommitmentMessage({
+      channel: channelAddress,
+      amount: commitmentAmount,
+      network,
     })
-      .addOperation(call)
-      .setTimeout(simulationTimeoutMs / 1000)
-      .build()
-
-    const simResult = await simulateCall(rpcServer, simTx, { timeoutMs: simulationTimeoutMs })
-
-    const returnValue = simResult.result?.retval
-    if (!returnValue) {
-      throw new ChannelVerificationError(`${LOG_PREFIX} prepare_commitment returned no value.`, {})
-    }
-
-    const commitmentBytes = returnValue.bytes()
-    const valid = commitmentKP.verify(Buffer.from(commitmentBytes), signatureBytes)
+    const valid = commitmentKP.verify(commitmentBytes, signatureBytes)
 
     if (!valid) {
       throw new ChannelVerificationError(
@@ -1172,11 +1162,14 @@ export declare namespace channel {
      */
     rpcUrl?: string
     /**
-     * Maximum credential verifications allowed to hold Soroban RPC simulations
-     * at once. Verification runs its simulations outside the cumulative lock so
-     * a slow RPC cannot stall concurrent payers, which makes this the only
+     * Maximum credential verifications allowed to hold an on-chain state read
+     * at once (`checkOnChainState`). The reads run outside the cumulative lock
+     * so a slow RPC cannot stall concurrent payers, which makes this the only
      * bound on RPC fan-out under a burst of credentials. Callers past the limit
      * queue briefly and are then rejected with a `SemaphoreTimeoutError`.
+     *
+     * Commitment signatures are verified against a locally-built message, so
+     * they never touch RPC and are not covered by this limit.
      *
      * @default 10
      */

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -693,27 +693,13 @@ export function channel(parameters: channel.Parameters) {
       return { windowStartMs, spentStroops: spentStroops + charge }
     }
 
-    // Prefer the store's atomic read-modify-write so the budget holds under
-    // concurrent settlements (which run outside the cumulative lock). Stores
-    // without `update` fall back to get/put — best-effort under cross-process
-    // races, acceptable for a fee-drain guard rather than a hard cap.
-    const atomicStore = store as {
-      update?: (
-        key: string,
-        fn: (current: FeeBudgetRecord | null) => Store.Change<FeeBudgetRecord, void>,
-      ) => Promise<void>
-    }
-
-    if (typeof atomicStore.update === 'function') {
-      await atomicStore.update(budgetKey, (current) => ({
-        op: 'set',
-        value: applyCharge(current),
-        result: undefined,
-      }))
-    } else {
-      const current = (await store.get(budgetKey)) as FeeBudgetRecord | null
-      await store.put(budgetKey, applyCharge(current))
-    }
+    // Atomic read-modify-write so the budget holds under concurrent settlements
+    // (which run outside the cumulative lock).
+    await store.update(budgetKey, (current): Store.Change<FeeBudgetRecord, void> => ({
+      op: 'set',
+      value: applyCharge(current as FeeBudgetRecord | null),
+      result: undefined,
+    }))
   }
 
   /**

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_POLL_MAX_ATTEMPTS,
   DEFAULT_POLL_MAX_CONCURRENT,
   DEFAULT_POLL_TIMEOUT_MS,
+  DEFAULT_SIMULATE_MAX_CONCURRENT,
   DEFAULT_SIMULATION_TIMEOUT_MS,
 } from '../../shared/defaults.js'
 import { Semaphore } from '../../shared/semaphore.js'
@@ -146,6 +147,7 @@ export function channel(parameters: channel.Parameters) {
     pollMaxConcurrent = DEFAULT_POLL_MAX_CONCURRENT,
     pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
     rpcUrl,
+    simulateMaxConcurrent = DEFAULT_SIMULATE_MAX_CONCURRENT,
     simulationTimeoutMs = DEFAULT_SIMULATION_TIMEOUT_MS,
     store,
     feeBudget,
@@ -156,6 +158,9 @@ export function channel(parameters: channel.Parameters) {
   const networkPassphrase = NETWORK_PASSPHRASE[network]
   const rpcServer = new rpc.Server(resolvedRpcUrl)
   const pollSemaphore = new Semaphore(pollMaxConcurrent)
+  // Bounds credential verifications holding RPC simulations concurrently. The
+  // simulations run outside cumulativeLock, so this is the only cap on fan-out.
+  const simulateSemaphore = new Semaphore(simulateMaxConcurrent)
 
   // Parse the commitment public key (accepts G... Stellar public key string or Keypair)
   const commitmentKP = (() => {
@@ -235,17 +240,26 @@ export function channel(parameters: channel.Parameters) {
       }
     },
     async verify({ credential }) {
-      // Phase 1: validate and update cumulative under lock (fast path).
-      // Phase 2: long operations (broadcast, poll) run outside the lock.
-      const validated = await new Promise<ValidatedCredential>((resolve, reject) => {
-        cumulativeLock = cumulativeLock.then(
-          () => doValidate(credential).then(resolve, reject),
-          () => doValidate(credential).then(resolve, reject),
-        )
-      })
+      // Phase 1a: format checks, replay claim, and RPC — outside the lock.
+      // Phase 1b: authoritative cumulative write — under the lock, store only.
+      // Phase 2: broadcast and poll for a close — outside the lock.
+      const prepared = await doPrepare(credential)
+      const validated = await withCumulativeLock(() => doCommit(prepared))
       return doSettle(validated)
     },
   })
+
+  /** Output of {@link doPrepare}: everything {@link doCommit} needs to write
+   *  channel state without re-reading the credential. */
+  type PreparedCredential = {
+    action: 'voucher' | 'close'
+    commitmentAmount: bigint
+    requestedAmount: bigint
+    signatureBytes: Buffer
+    challengeStoreKey: string
+    challengeReference: string
+    externalId?: string
+  }
 
   type ValidatedCredential =
     | { action: 'voucher'; receipt: Receipt.Receipt }
@@ -258,21 +272,29 @@ export function channel(parameters: channel.Parameters) {
       }
 
   /**
-   * Phase 1 — validation (runs under {@link cumulativeLock}).
+   * Serializes `fn` against every other holder of the cumulative lock.
    *
-   * Performs replay protection, cumulative amount checks, and signature
-   * verification. For vouchers, writes the cumulative and returns the
-   * receipt directly. For close, returns the validated state so
-   * the long on-chain operation can run outside the lock.
+   * The same callback is passed to both `.then` arms so a rejected predecessor
+   * does not poison the chain — without the second arm, one failed validation
+   * would leave `cumulativeLock` permanently rejected and every later caller
+   * would skip its turn.
    */
-  async function doValidate(credential: ChannelCredential): Promise<ValidatedCredential> {
-    const { challenge, payload } = credential
-    const { request: challengeRequest } = challenge
+  function withCumulativeLock<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      cumulativeLock = cumulativeLock.then(
+        () => fn().then(resolve, reject),
+        () => fn().then(resolve, reject),
+      )
+    })
+  }
 
-    const action = payload.action ?? 'voucher'
-    const { externalId } = challengeRequest
-
-    // Reject credentials once the channel has been closed on-chain. Applied to all actions.
+  /**
+   * Rejects credentials once the channel has been closed on-chain.
+   *
+   * Read by both phases: {@link doPrepare} rejects early to avoid spending RPC,
+   * and {@link doCommit} re-reads because an RPC round-trip has elapsed since.
+   */
+  async function assertNotClosed(): Promise<void> {
     const closed = await store.get(`${STORE_PREFIX}:closed:${channelAddress}`)
     if (closed) {
       logger.warn(`${LOG_PREFIX} Rejecting credential — channel already closed`, {
@@ -283,6 +305,31 @@ export function channel(parameters: channel.Parameters) {
         { channel: channelAddress },
       )
     }
+  }
+
+  /**
+   * Phase 1a — checks and RPC (runs OUTSIDE {@link cumulativeLock}).
+   *
+   * Claims the challenge, validates formats, and proves the commitment
+   * signature authentic. Nothing here writes channel state beyond the
+   * self-synchronising challenge claim, so the lifecycle reads are advisory:
+   * they shed obvious rejects before any RPC is spent, and the authoritative
+   * checks run in {@link doCommit} under the lock.
+   *
+   * Keeping RPC out of the lock is deliberate. A simulation is bounded by
+   * `simulationTimeoutMs` (default 10s) and the on-chain state query costs
+   * several more calls; holding the lock across them lets a single credential
+   * stall every concurrent payer on this channel.
+   */
+  async function doPrepare(credential: ChannelCredential): Promise<PreparedCredential> {
+    const { challenge, payload } = credential
+    const { request: challengeRequest } = challenge
+
+    const action = payload.action ?? 'voucher'
+    const { externalId } = challengeRequest
+
+    // Advisory lifecycle reads — re-checked authoritatively in doCommit.
+    await assertNotClosed()
 
     // Reject all actions if a close is currently settling. The settling marker is set
     // atomically under the lock when a close is accepted, and remains set until settlement
@@ -315,7 +362,8 @@ export function channel(parameters: channel.Parameters) {
     }
 
     // Replay protection via atomic compare-and-set: reject if challenge already used.
-    // Applied to all actions.
+    // Applied to all actions. Self-synchronising, so it needs no lock — and it runs
+    // ahead of the RPC below so replayed challenges are shed without a round-trip.
     const challengeStoreKey = `${STORE_PREFIX}:challenge:${challenge.id}`
     const replayError = new ChannelVerificationError('Challenge already used. Replay rejected.', {
       channel: channelAddress,
@@ -354,8 +402,9 @@ export function channel(parameters: channel.Parameters) {
     // Cheap monotonicity short-circuit before any RPC work: a commitment that
     // cannot advance the cumulative is rejected here, so a flood of stale or
     // non-monotonic commitments cannot amplify into signature-verify and
-    // on-chain-state RPC load. The atomic store.update below stays authoritative,
-    // re-reading the latest cumulative to remain correct under concurrent writes.
+    // on-chain-state RPC load. The atomic store.update in doCommit stays
+    // authoritative, re-reading the latest cumulative to remain correct under
+    // concurrent writes.
     const preCheckError = cumulativeMonotonicityError(
       readCumulativeAmount(cumulativeRecord),
       commitmentAmount,
@@ -365,16 +414,24 @@ export function channel(parameters: channel.Parameters) {
       throw preCheckError
     }
 
-    // Verify commitment signature before atomic cumulative update
-    // (async work must complete before the atomic CAS)
-    await verifyCommitmentSignature(commitmentAmount, signatureBytes)
+    // Bound concurrent RPC. The cumulative lock used to cap simulations at one
+    // in flight as a side effect of serialising validation; now that the RPC
+    // runs unlocked, that cap has to be explicit or a burst of credentials fans
+    // straight out onto the RPC provider.
+    await simulateSemaphore.acquire()
+    try {
+      // Verify the commitment signature before anything writes channel state.
+      await verifyCommitmentSignature(commitmentAmount, signatureBytes)
 
-    // Query on-chain state only after the commitment signature is proven
-    // authentic. The state read costs several RPC calls; gating it behind the
-    // cheaper signature check stops a forged voucher from amplifying into the
-    // full state query.
-    if (checkOnChainState) {
-      await verifyOnChainState(commitmentAmount)
+      // Query on-chain state only after the commitment signature is proven
+      // authentic. The state read costs several RPC calls; gating it behind the
+      // cheaper signature check stops a forged voucher from amplifying into the
+      // full state query.
+      if (checkOnChainState) {
+        await verifyOnChainState(commitmentAmount)
+      }
+    } finally {
+      simulateSemaphore.release()
     }
 
     // A close can only be settled by a server configured with an envelope signer.
@@ -386,6 +443,41 @@ export function channel(parameters: channel.Parameters) {
         {},
       )
     }
+
+    return {
+      action,
+      commitmentAmount,
+      requestedAmount,
+      signatureBytes,
+      challengeStoreKey,
+      challengeReference: challengeRequest.methodDetails?.reference ?? challenge.id,
+      ...(externalId ? { externalId } : {}),
+    }
+  }
+
+  /**
+   * Phase 1b — authoritative state write (runs UNDER {@link cumulativeLock}).
+   *
+   * Holds the lock for store operations only: one atomic cumulative update plus
+   * a marker write. For vouchers this returns the receipt directly; for a close
+   * it returns the validated state so settlement can run outside the lock.
+   */
+  async function doCommit(prepared: PreparedCredential): Promise<ValidatedCredential> {
+    const {
+      action,
+      commitmentAmount,
+      requestedAmount,
+      signatureBytes,
+      challengeStoreKey,
+      challengeReference,
+      externalId,
+    } = prepared
+
+    // Re-read: an RPC round-trip elapsed inside doPrepare, so its lifecycle
+    // reads may be seconds stale. The cumulative update below covers `settling`
+    // (that flag lives in the cumulative record); `closed` is a separate key and
+    // has to be re-read here.
+    await assertNotClosed()
 
     // Atomic cumulative monotonic check and write: reject if invariants fail,
     // or write the new cumulative if all checks pass.
@@ -413,7 +505,7 @@ export function channel(parameters: channel.Parameters) {
         }
 
         // Authoritative monotonicity check against the latest stored cumulative,
-        // applying the same rules as the pre-RPC short-circuit above.
+        // applying the same rules as the pre-RPC short-circuit in doPrepare.
         const monotonicityError = cumulativeMonotonicityError(
           previousCumulative,
           commitmentAmount,
@@ -463,7 +555,7 @@ export function channel(parameters: channel.Parameters) {
       action: 'voucher',
       receipt: Receipt.from({
         method: 'stellar',
-        reference: challengeRequest.methodDetails?.reference ?? challenge.id,
+        reference: challengeReference,
         status: 'success',
         timestamp: new Date().toISOString(),
         ...(externalId ? { externalId } : {}),
@@ -1079,6 +1171,16 @@ export declare namespace channel {
      * ```
      */
     rpcUrl?: string
+    /**
+     * Maximum credential verifications allowed to hold Soroban RPC simulations
+     * at once. Verification runs its simulations outside the cumulative lock so
+     * a slow RPC cannot stall concurrent payers, which makes this the only
+     * bound on RPC fan-out under a burst of credentials. Callers past the limit
+     * queue briefly and are then rejected with a `SemaphoreTimeoutError`.
+     *
+     * @default 10
+     */
+    simulateMaxConcurrent?: number
     /** Simulation timeout in milliseconds. @default 10_000 */
     simulationTimeoutMs?: number
     /**

--- a/sdk/src/shared/defaults.ts
+++ b/sdk/src/shared/defaults.ts
@@ -8,6 +8,12 @@ export const DEFAULT_POLL_JITTER_MS = 200
 export const DEFAULT_POLL_TIMEOUT_MS = 20_000
 export const DEFAULT_POLL_MAX_CONCURRENT = 10
 export const DEFAULT_SIMULATION_TIMEOUT_MS = 10_000
+/**
+ * Maximum credential verifications allowed to hold Soroban RPC simulations at
+ * once. Channel verification runs its simulations outside the cumulative lock,
+ * so this is the only bound on RPC fan-out under a burst of credentials.
+ */
+export const DEFAULT_SIMULATE_MAX_CONCURRENT = 10
 
 /**
  * Default timeout in seconds for read-only contract getter simulations (State.ts).

--- a/sdk/src/shared/defaults.ts
+++ b/sdk/src/shared/defaults.ts
@@ -9,9 +9,9 @@ export const DEFAULT_POLL_TIMEOUT_MS = 20_000
 export const DEFAULT_POLL_MAX_CONCURRENT = 10
 export const DEFAULT_SIMULATION_TIMEOUT_MS = 10_000
 /**
- * Maximum credential verifications allowed to hold Soroban RPC simulations at
- * once. Channel verification runs its simulations outside the cumulative lock,
- * so this is the only bound on RPC fan-out under a burst of credentials.
+ * Maximum credential verifications allowed to hold an on-chain channel state
+ * read at once. Those reads run outside the cumulative lock, so this is the
+ * only bound on RPC fan-out under a burst of credentials.
  */
 export const DEFAULT_SIMULATE_MAX_CONCURRENT = 10
 


### PR DESCRIPTION
Related to https://github.com/stellar/stellar-mpp-sdk/pull/61 so it's based off of that PR. 

I noticed while reading the mpp docs on solana and tempo that their entire verification during the session happens offchain. Meanwhile, we call RPC to verify. This should be done locally.  Our `one-way-channel` also [mentions](https://github.com/stellar-experimental/one-way-channel/blob/main/contracts/channel/src/lib.rs#L408-L409) that

> Commitments are typically prepared off-chain. This function is provided as a convenience.

The SDK was calling it once per voucher on both sides. The commitment message is fully determined by the amount, channel, network, and a constant domain separator — all known locally — so it's now built directly. Signing and verification are CPU-only, and a payer no longer needs RPC reachability to sign.

This also prevents unauthenticated simulation output. A compromised or intercepted RPC could have returned a commitment for a smaller amount than the one credited. Locally-built bytes can't disagree with the amount being credited.

A live parity test (sdk/src/channel/integration/live/) asserts the local encoding matches a deployed contract byte-for-byte, replacing the round trip as the drift guard.