### PR TITLE
chore: bump @toon-format/toon to 2.3.1 in lockfile 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,8 +500,8 @@ packages:
     resolution: {integrity: sha512-DHJpol/98VKyojNSYmpkB5vOMnlf87hPe0wPxyaYTNiTMk5QjKMXDfSZLwGctYIXAgAWDFeRABc8lFAj0BELyw==}
     engines: {node: '>=12.16'}
 
-  '@toon-format/toon@2.3.0':
-    resolution: {integrity: sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w==}
+  '@toon-format/toon@2.3.1':
+    resolution: {integrity: sha512-sWqEMeAJGMda9qRrfPKrX3C4c33CO9SJuvJzzrcBEn5sbDB+k6pSLkDsfN0rVnLQwR97MV3sDgVbcxQNsq8xVw==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1355,8 +1355,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   pino-abstract-transport@3.0.0:
@@ -2012,7 +2012,7 @@ snapshots:
 
   '@stripe/stripe-js@9.8.0': {}
 
-  '@toon-format/toon@2.3.0': {}
+  '@toon-format/toon@2.3.1': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -2670,7 +2670,7 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/server': 2.0.0-alpha.3
       '@scalar/openapi-types': 0.8.0
-      '@toon-format/toon': 2.3.0
+      '@toon-format/toon': 2.3.1
       tokenx: 1.3.0
       yaml: 2.9.0
       zod: 4.4.3
@@ -2897,7 +2897,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  picomatch@4.0.5: {}
+  picomatch@4.0.7: {}
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -3174,7 +3174,7 @@ snapshots:
   vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       postcss: 8.5.26
       rolldown: 1.1.5
       tinyglobby: 0.2.17


### PR DESCRIPTION
`pnpm audit --audit-level high` fails on `main`, which turns `check-test-build` red on every open PR

```
high  @toon-format/toon <2.3.1  Prototype pollution when decoding untrusted TOON input
Paths: .>mppx>incur>@toon-format/toon
https://github.com/advisories/GHSA-p95v-992w-h6c3
```

`incur@0.4.10` already declares `@toon-format/toon: ^2.1.0`, and the patched version is `2.3.1` — inside that range. So this is a lockfile-only bump: no `pnpm.overrides`, no manifest change. `picomatch` 4.0.5 → 4.0.7 (transitive under `vite`, dev-only) came along in the same re-resolution.

Both versions were selected by pnpm under this repo's 7-day `minimumReleaseAge` soak, so neither is a fresh release.

## Verification

`make check` green end to end:

- format-check, lint, typecheck: clean
- tests: 27 files / 495 passed
- build: clean
- `pnpm audit --audit-level high`: `4 vulnerabilities found / Severity: 4 moderate` — no high, exits 0

## Note

Merging this unblocks #69, which is approved but cannot go green on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)